### PR TITLE
feat: Web UI でトレーサビリティデモを実施可能にする

### DIFF
--- a/docs/web-demo-guide.md
+++ b/docs/web-demo-guide.md
@@ -1,0 +1,118 @@
+# Web デモガイド
+
+ブラウザ上でサプライチェーン・トレーサビリティのデモを実施する手順。
+
+---
+
+## 前提条件
+
+- Fabric ネットワーク起動済み (`./scripts/network_up.sh`)
+- Chaincode デプロイ済み (`./scripts/deploy_chaincode.sh`)
+- Node.js >= 18
+
+## 起動
+
+```bash
+./scripts/web_demo.sh
+```
+
+ブラウザで `http://localhost:3000` を開く。
+
+## 停止
+
+ターミナルで `Ctrl+C`。
+
+---
+
+## 画面構成
+
+| エリア | 説明 |
+|---|---|
+| ヘッダー | 操作組織の選択（メーカー A / 卸 B / 販売店 C） |
+| 製品登録 | 製品 ID を入力して登録（メーカー A のみ） |
+| 製品移転 | 製品 ID と移転先を指定して移転 |
+| 製品照会 | 製品 ID で現在の状態を確認 |
+| 来歴照会 | 製品 ID で全履歴をタイムライン表示 |
+| 結果表示 | 操作結果・エラーメッセージを表示 |
+
+---
+
+## デモシナリオ（正常系）
+
+### N1: 製品登録
+
+1. 組織を **メーカー A** に切替
+2. 「製品登録」パネルで製品 ID に `X001` を入力
+3. 「登録」ボタンをクリック
+4. 結果: `currentOwner: Org1MSP` が表示される
+
+### N2: A → B へ移転
+
+1. 組織は **メーカー A** のまま
+2. 「製品移転」パネルで製品 ID に `X001`、移転先に `Org2MSP - 卸 B` を選択
+3. 「移転」ボタンをクリック
+4. 結果: `currentOwner: Org2MSP` に更新
+
+### N3: B → C へ移転
+
+1. 組織を **卸 B** に切替
+2. 「製品移転」パネルで製品 ID に `X001`、移転先に `Org3MSP - 販売店 C` を選択
+3. 「移転」ボタンをクリック
+4. 結果: `currentOwner: Org3MSP` に更新
+
+### N4: C による来歴確認
+
+1. 組織を **販売店 C** に切替
+2. 「来歴照会」パネルで製品 ID に `X001` を入力
+3. 「来歴確認」ボタンをクリック
+4. 結果:
+   - フローチェーン: `メーカー A → 卸 B → 販売店 C`
+   - 起点検証: 「OK: メーカー A (Org1MSP) が登録」
+   - タイムライン: CREATE → TRANSFER → TRANSFER の 3 イベント
+
+---
+
+## デモシナリオ（異常系）
+
+### E1: 所有者偽装
+
+1. 組織を **メーカー A** に切替
+2. `X001` を移転しようとする（既に C が所有）
+3. 結果: エラー「fromOwner does not match currentOwner」
+
+### E2: 未登録照会
+
+1. 「製品照会」で `X999` を照会
+2. 結果: エラー「product not found: X999」
+
+### E3: 重複登録
+
+1. 組織を **メーカー A** に切替
+2. 既に登録済みの `X001` を再登録
+3. 結果: エラー「product already exists: X001」
+
+---
+
+## トラブルシューティング
+
+| 症状 | 対処 |
+|---|---|
+| `Fabric ネットワーク未起動` | `./scripts/network_up.sh` を実行 |
+| `Chaincode 未デプロイ` | `./scripts/deploy_chaincode.sh` を実行 |
+| `npm install` 失敗 | Node.js >= 18 か確認。`rm -rf web/node_modules && ./scripts/web_demo.sh` |
+| gRPC 接続エラー | Fabric コンテナが正常か `docker ps` で確認 |
+| ポート 3000 使用中 | `PORT=3001 ./scripts/web_demo.sh` で別ポート指定 |
+
+---
+
+## REST API リファレンス
+
+全エンドポイントにクエリパラメータ `?org=org1|org2|org3` で操作組織を指定。
+
+| Method | Path | Body | 説明 |
+|---|---|---|---|
+| GET | `/api/orgs` | - | 組織一覧 |
+| POST | `/api/products` | `{"productId":"X001"}` | 製品登録 |
+| POST | `/api/products/:id/transfer` | `{"toOwner":"Org2MSP"}` | 製品移転 |
+| GET | `/api/products/:id` | - | 製品照会 |
+| GET | `/api/products/:id/history` | - | 来歴照会 |

--- a/scripts/web_demo.sh
+++ b/scripts/web_demo.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# web_demo.sh — Web デモ UI 起動スクリプト
+#
+# Usage:
+#   ./scripts/web_demo.sh          # Web サーバー起動
+#   ./scripts/web_demo.sh --stop   # 停止（バックグラウンド実行時）
+#
+# 前提:
+#   - Fabric ネットワーク起動済み (./scripts/network_up.sh)
+#   - Chaincode デプロイ済み (./scripts/deploy_chaincode.sh)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WEB_DIR="${REPO_ROOT}/web"
+
+if [[ -t 1 ]]; then
+  C_HDR=$'\033[1;36m'; C_OK=$'\033[32m'; C_ERR=$'\033[31m'; C_OFF=$'\033[0m'
+else
+  C_HDR=""; C_OK=""; C_ERR=""; C_OFF=""
+fi
+log()  { echo "${C_HDR}[web-demo]${C_OFF} $*"; }
+ok()   { echo "${C_OK}[web-demo]${C_OFF} $*"; }
+err()  { echo "${C_ERR}[web-demo]${C_OFF} $*" >&2; }
+
+# --stop: kill running server
+if [[ "${1:-}" == "--stop" ]]; then
+  if [[ -f "${WEB_DIR}/.pid" ]]; then
+    PID=$(cat "${WEB_DIR}/.pid")
+    if kill -0 "$PID" 2>/dev/null; then
+      kill "$PID"
+      ok "Server stopped (PID=$PID)"
+    else
+      log "Server not running (stale PID=$PID)"
+    fi
+    rm -f "${WEB_DIR}/.pid"
+  else
+    log "No .pid file found"
+  fi
+  exit 0
+fi
+
+# --- Preflight checks ---
+
+log "Preflight: Fabric ネットワーク確認..."
+if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^peer0.org1.example.com$'; then
+  err "Fabric ネットワーク未起動。先に実行:"
+  err "  ./scripts/network_up.sh"
+  exit 1
+fi
+ok "Fabric ネットワーク起動中"
+
+log "Preflight: Chaincode デプロイ確認..."
+PEER_BIN="${REPO_ROOT}/fabric/fabric-samples/bin/peer"
+export FABRIC_CFG_PATH="${REPO_ROOT}/fabric/fabric-samples/config"
+TEST_NET_DIR="${REPO_ROOT}/fabric/fabric-samples/test-network"
+ORG1_DIR="${TEST_NET_DIR}/organizations/peerOrganizations/org1.example.com"
+export CORE_PEER_TLS_ENABLED=true
+export CORE_PEER_LOCALMSPID="Org1MSP"
+export CORE_PEER_TLS_ROOTCERT_FILE="${ORG1_DIR}/peers/peer0.org1.example.com/tls/ca.crt"
+export CORE_PEER_MSPCONFIGPATH="${ORG1_DIR}/users/Admin@org1.example.com/msp"
+export CORE_PEER_ADDRESS=localhost:7051
+
+CC_NAME="${CC_NAME:-product-trace}"
+CHANNEL_NAME="${CHANNEL_NAME:-supplychannel}"
+
+if ! "${PEER_BIN}" lifecycle chaincode querycommitted -C "${CHANNEL_NAME}" -n "${CC_NAME}" >/dev/null 2>&1; then
+  err "Chaincode '${CC_NAME}' 未デプロイ。先に実行:"
+  err "  ./scripts/deploy_chaincode.sh"
+  exit 1
+fi
+ok "Chaincode '${CC_NAME}' デプロイ済み"
+
+# --- npm install ---
+
+log "npm install..."
+cd "${WEB_DIR}"
+if [[ ! -d node_modules ]]; then
+  npm install --no-fund --no-audit 2>&1 | tail -1
+else
+  log "node_modules 存在 → スキップ (再インストールは rm -rf web/node_modules 後に再実行)"
+fi
+
+# --- Start server ---
+
+log "Web サーバーを起動します..."
+echo ""
+ok "=========================================="
+ok "  http://localhost:${PORT:-3000}"
+ok "=========================================="
+echo ""
+log "Ctrl+C で停止"
+
+exec node server.js

--- a/scripts/web_demo.sh
+++ b/scripts/web_demo.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# fabric-samples が別ディレクトリにある場合は FABRIC_REPO_ROOT で上書き可能
+FABRIC_REPO_ROOT="${FABRIC_REPO_ROOT:-${REPO_ROOT}}"
+export FABRIC_REPO_ROOT
 WEB_DIR="${REPO_ROOT}/web"
 
 if [[ -t 1 ]]; then
@@ -52,9 +55,9 @@ fi
 ok "Fabric ネットワーク起動中"
 
 log "Preflight: Chaincode デプロイ確認..."
-PEER_BIN="${REPO_ROOT}/fabric/fabric-samples/bin/peer"
-export FABRIC_CFG_PATH="${REPO_ROOT}/fabric/fabric-samples/config"
-TEST_NET_DIR="${REPO_ROOT}/fabric/fabric-samples/test-network"
+PEER_BIN="${FABRIC_REPO_ROOT}/fabric/fabric-samples/bin/peer"
+export FABRIC_CFG_PATH="${FABRIC_REPO_ROOT}/fabric/fabric-samples/config"
+TEST_NET_DIR="${FABRIC_REPO_ROOT}/fabric/fabric-samples/test-network"
 ORG1_DIR="${TEST_NET_DIR}/organizations/peerOrganizations/org1.example.com"
 export CORE_PEER_TLS_ENABLED=true
 export CORE_PEER_LOCALMSPID="Org1MSP"

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hl-proto-web",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Web demo UI for hl-proto supply chain traceability",
+  "main": "server.js",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.12.5",
+    "@hyperledger/fabric-gateway": "^1.7.1",
+    "express": "^4.21.2"
+  }
+}

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,0 +1,195 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// MSP label map
+// ---------------------------------------------------------------------------
+const MSP_LABELS = {
+  Org1MSP: 'メーカー A',
+  Org2MSP: '卸 B',
+  Org3MSP: '販売店 C',
+};
+
+function mspLabel(mspId) {
+  return MSP_LABELS[mspId] || mspId;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+let currentOrg = 'org1';
+
+const orgSelect = document.getElementById('orgSelect');
+const orgBadge = document.getElementById('orgBadge');
+const resultArea = document.getElementById('resultArea');
+
+// ---------------------------------------------------------------------------
+// Org switch
+// ---------------------------------------------------------------------------
+orgSelect.addEventListener('change', () => {
+  currentOrg = orgSelect.value;
+  document.body.className = currentOrg;
+  orgBadge.className = `badge ${currentOrg}`;
+  const orgMap = { org1: 'Org1MSP', org2: 'Org2MSP', org3: 'Org3MSP' };
+  orgBadge.textContent = orgMap[currentOrg];
+});
+// Init
+document.body.className = currentOrg;
+
+// ---------------------------------------------------------------------------
+// API helper
+// ---------------------------------------------------------------------------
+async function apiCall(method, path, body) {
+  const sep = path.includes('?') ? '&' : '?';
+  const url = `${path}${sep}org=${currentOrg}`;
+  const opts = { method, headers: {} };
+  if (body) {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, opts);
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+function showLoading() {
+  resultArea.innerHTML = '<div class="loading">処理中...</div>';
+}
+
+function showError(msg) {
+  resultArea.innerHTML = `<div class="result-error">${escapeHtml(msg)}</div>`;
+}
+
+function showSuccess(label, data) {
+  resultArea.innerHTML =
+    `<div class="result-success"><strong>${escapeHtml(label)}</strong></div>` +
+    `<pre>${escapeHtml(JSON.stringify(data, null, 2))}</pre>`;
+}
+
+function escapeHtml(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+// ---------------------------------------------------------------------------
+// CreateProduct
+// ---------------------------------------------------------------------------
+document.getElementById('btnCreate').addEventListener('click', async () => {
+  const productId = document.getElementById('createProductId').value.trim();
+  if (!productId) return showError('製品 ID を入力してください');
+  showLoading();
+  try {
+    const data = await apiCall('POST', '/api/products', { productId });
+    showSuccess('製品を登録しました', data);
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// TransferProduct
+// ---------------------------------------------------------------------------
+document.getElementById('btnTransfer').addEventListener('click', async () => {
+  const productId = document.getElementById('transferProductId').value.trim();
+  const toOwner = document.getElementById('transferTo').value;
+  if (!productId) return showError('製品 ID を入力してください');
+  showLoading();
+  try {
+    const data = await apiCall('POST', `/api/products/${encodeURIComponent(productId)}/transfer`, { toOwner });
+    showSuccess('移転が完了しました', data);
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// ReadProduct
+// ---------------------------------------------------------------------------
+document.getElementById('btnRead').addEventListener('click', async () => {
+  const productId = document.getElementById('readProductId').value.trim();
+  if (!productId) return showError('製品 ID を入力してください');
+  showLoading();
+  try {
+    const data = await apiCall('GET', `/api/products/${encodeURIComponent(productId)}`);
+    showSuccess(`製品情報: ${productId}`, data);
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GetHistory — with timeline + flow visualization
+// ---------------------------------------------------------------------------
+document.getElementById('btnHistory').addEventListener('click', async () => {
+  const productId = document.getElementById('historyProductId').value.trim();
+  if (!productId) return showError('製品 ID を入力してください');
+  showLoading();
+  try {
+    const events = await apiCall('GET', `/api/products/${encodeURIComponent(productId)}/history`);
+    renderHistory(productId, events);
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+function renderHistory(productId, events) {
+  if (!events || events.length === 0) {
+    resultArea.innerHTML = '<div class="result-error">履歴が見つかりません</div>';
+    return;
+  }
+
+  // Build flow chain: extract unique owners in order
+  const owners = [];
+  for (const ev of events) {
+    if (ev.eventType === 'CREATE' && ev.toOwner && !owners.includes(ev.toOwner)) {
+      owners.push(ev.toOwner);
+    }
+    if (ev.eventType === 'TRANSFER') {
+      if (ev.fromOwner && !owners.includes(ev.fromOwner)) owners.push(ev.fromOwner);
+      if (ev.toOwner && !owners.includes(ev.toOwner)) owners.push(ev.toOwner);
+    }
+  }
+
+  // Flow chain HTML
+  let flowHtml = '<div class="flow-chain">';
+  owners.forEach((o, i) => {
+    if (i > 0) flowHtml += '<span class="flow-arrow">&rarr;</span>';
+    flowHtml += `<span class="flow-node ${escapeHtml(o)}">${escapeHtml(mspLabel(o))}</span>`;
+  });
+  flowHtml += '</div>';
+
+  // Verify origin
+  const origin = events[0];
+  const isOriginA = origin.eventType === 'CREATE' && origin.toOwner === 'Org1MSP';
+  const verifyClass = isOriginA ? 'verify-ok' : 'verify-ng';
+  const verifyMsg = isOriginA
+    ? `起点検証 OK: 製品 ${escapeHtml(productId)} はメーカー A (Org1MSP) が登録`
+    : `起点検証 NG: 製品 ${escapeHtml(productId)} の登録者は ${escapeHtml(mspLabel(origin.toOwner || '不明'))}`;
+  const verifyHtml = `<div class="verify-result ${verifyClass}">${verifyMsg}</div>`;
+
+  // Timeline
+  let timelineHtml = '<ul class="timeline">';
+  for (const ev of events) {
+    const cls = `event-${ev.eventType}`;
+    let detail = '';
+    if (ev.eventType === 'CREATE') {
+      detail = `登録者: ${escapeHtml(mspLabel(ev.toOwner))}`;
+    } else {
+      detail = `${escapeHtml(mspLabel(ev.fromOwner))} → ${escapeHtml(mspLabel(ev.toOwner))}`;
+    }
+    const ts = ev.timestamp ? new Date(ev.timestamp).toLocaleString('ja-JP') : '';
+    const txShort = ev.txId ? ev.txId.substring(0, 12) + '...' : '';
+    timelineHtml += `
+      <li class="${cls}">
+        <div class="event-type">${escapeHtml(ev.eventType)}</div>
+        <div class="event-detail">${detail}</div>
+        <div class="event-detail">${escapeHtml(ts)}${txShort ? ' | tx: ' + escapeHtml(txShort) : ''}</div>
+      </li>`;
+  }
+  timelineHtml += '</ul>';
+
+  resultArea.innerHTML =
+    `<div class="result-success"><strong>来歴: ${escapeHtml(productId)}</strong></div>` +
+    flowHtml + verifyHtml + timelineHtml;
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HL-Proto Supply Chain Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Supply Chain Traceability Demo</h1>
+    <div class="org-selector">
+      <label for="orgSelect">操作組織:</label>
+      <select id="orgSelect">
+        <option value="org1">Org1MSP - メーカー A</option>
+        <option value="org2">Org2MSP - 卸 B</option>
+        <option value="org3">Org3MSP - 販売店 C</option>
+      </select>
+      <span id="orgBadge" class="badge org1">Org1MSP</span>
+    </div>
+  </header>
+
+  <main>
+    <div class="panels">
+      <!-- 製品登録 -->
+      <section class="panel" id="panelCreate">
+        <h2>製品登録 (CreateProduct)</h2>
+        <p class="hint">メーカー A (Org1MSP) のみ実行可能</p>
+        <div class="form-row">
+          <label for="createProductId">製品 ID:</label>
+          <input type="text" id="createProductId" placeholder="例: X001">
+        </div>
+        <button id="btnCreate">登録</button>
+      </section>
+
+      <!-- 製品移転 -->
+      <section class="panel" id="panelTransfer">
+        <h2>製品移転 (TransferProduct)</h2>
+        <p class="hint">現在の所有者として操作。移転先を選択。</p>
+        <div class="form-row">
+          <label for="transferProductId">製品 ID:</label>
+          <input type="text" id="transferProductId" placeholder="例: X001">
+        </div>
+        <div class="form-row">
+          <label for="transferTo">移転先:</label>
+          <select id="transferTo">
+            <option value="Org1MSP">Org1MSP - メーカー A</option>
+            <option value="Org2MSP" selected>Org2MSP - 卸 B</option>
+            <option value="Org3MSP">Org3MSP - 販売店 C</option>
+          </select>
+        </div>
+        <button id="btnTransfer">移転</button>
+      </section>
+
+      <!-- 製品照会 -->
+      <section class="panel" id="panelRead">
+        <h2>製品照会 (ReadProduct)</h2>
+        <div class="form-row">
+          <label for="readProductId">製品 ID:</label>
+          <input type="text" id="readProductId" placeholder="例: X001">
+        </div>
+        <button id="btnRead">照会</button>
+      </section>
+
+      <!-- 履歴照会 -->
+      <section class="panel" id="panelHistory">
+        <h2>来歴照会 (GetHistory)</h2>
+        <p class="hint">製品の全履歴を時系列で表示</p>
+        <div class="form-row">
+          <label for="historyProductId">製品 ID:</label>
+          <input type="text" id="historyProductId" placeholder="例: X001">
+        </div>
+        <button id="btnHistory">来歴確認</button>
+      </section>
+    </div>
+
+    <!-- 結果表示 -->
+    <section id="resultSection">
+      <h2>結果</h2>
+      <div id="resultArea"></div>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -1,0 +1,248 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --org1: #2563eb;
+  --org2: #16a34a;
+  --org3: #ea580c;
+  --bg: #f8fafc;
+  --card: #ffffff;
+  --border: #e2e8f0;
+  --text: #1e293b;
+  --text-light: #64748b;
+  --radius: 8px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+header {
+  background: var(--card);
+  border-bottom: 2px solid var(--border);
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+header h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.org-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.org-selector label { font-weight: 600; }
+
+.org-selector select {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+}
+
+.badge {
+  padding: 4px 12px;
+  border-radius: 20px;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+.badge.org1 { background: var(--org1); }
+.badge.org2 { background: var(--org2); }
+.badge.org3 { background: var(--org3); }
+
+main { padding: 24px; max-width: 1200px; margin: 0 auto; }
+
+.panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.panel {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.panel h2 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 8px;
+}
+
+.panel .hint {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  margin-bottom: 12px;
+}
+
+.form-row {
+  margin-bottom: 10px;
+}
+.form-row label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.form-row input,
+.form-row select {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+}
+
+button {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+button:hover { opacity: 0.85; }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Org-themed buttons */
+body.org1 button { background: var(--org1); }
+body.org2 button { background: var(--org2); }
+body.org3 button { background: var(--org3); }
+
+#resultSection {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+#resultSection h2 {
+  font-size: 1rem;
+  margin-bottom: 12px;
+}
+
+#resultArea {
+  min-height: 60px;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Error display */
+.result-error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 16px;
+  border-radius: var(--radius);
+}
+
+.result-success {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #166534;
+  padding: 12px 16px;
+  border-radius: var(--radius);
+}
+
+/* History timeline */
+.timeline { list-style: none; position: relative; padding-left: 24px; }
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border);
+}
+.timeline li {
+  position: relative;
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: var(--bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+.timeline li::before {
+  content: '';
+  position: absolute;
+  left: -20px;
+  top: 16px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--org1);
+  border: 2px solid #fff;
+}
+.timeline li.event-CREATE::before { background: var(--org1); }
+.timeline li.event-TRANSFER::before { background: var(--org2); }
+
+.timeline .event-type {
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+.timeline .event-detail {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  margin-top: 4px;
+}
+
+/* Flow visualization */
+.flow-chain {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.flow-node {
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: #fff;
+}
+.flow-node.Org1MSP { background: var(--org1); }
+.flow-node.Org2MSP { background: var(--org2); }
+.flow-node.Org3MSP { background: var(--org3); }
+.flow-arrow { font-size: 1.2rem; color: var(--text-light); }
+
+.verify-result {
+  padding: 10px 16px;
+  border-radius: var(--radius);
+  font-weight: 600;
+  margin-top: 12px;
+}
+.verify-ok {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #166534;
+}
+.verify-ng {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+
+/* Loading */
+.loading { color: var(--text-light); font-style: italic; }

--- a/web/server.js
+++ b/web/server.js
@@ -14,7 +14,7 @@ const PORT = process.env.PORT || 3000;
 const CHANNEL_NAME = process.env.CHANNEL_NAME || 'supplychannel';
 const CC_NAME = process.env.CC_NAME || 'product-trace';
 
-const REPO_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = process.env.FABRIC_REPO_ROOT || path.resolve(__dirname, '..');
 const TEST_NET_DIR = path.join(REPO_ROOT, 'fabric', 'fabric-samples', 'test-network');
 const ORGS_DIR = path.join(TEST_NET_DIR, 'organizations', 'peerOrganizations');
 
@@ -95,6 +95,12 @@ async function getContract(orgName) {
   return network.getContract(CC_NAME);
 }
 
+// fabric-gateway returns Uint8Array; .toString() yields comma-separated bytes
+const utf8Decoder = new TextDecoder();
+function decodeResult(result) {
+  return utf8Decoder.decode(result);
+}
+
 // ---------------------------------------------------------------------------
 // Express App
 // ---------------------------------------------------------------------------
@@ -131,7 +137,7 @@ app.post('/api/products', resolveOrg, async (req, res) => {
     const contract = await getContract(req.org);
     const mspId = ORG_CONFIG[req.org].mspId;
     const result = await contract.submitTransaction('CreateProduct', productId, mspId, mspId);
-    res.json(JSON.parse(result.toString()));
+    res.json(JSON.parse(decodeResult(result)));
   } catch (err) {
     const msg = extractChaincodeError(err);
     res.status(400).json({ error: msg });
@@ -147,7 +153,7 @@ app.post('/api/products/:id/transfer', resolveOrg, async (req, res) => {
     const contract = await getContract(req.org);
     const fromOwner = ORG_CONFIG[req.org].mspId;
     const result = await contract.submitTransaction('TransferProduct', id, fromOwner, toOwner);
-    res.json(JSON.parse(result.toString()));
+    res.json(JSON.parse(decodeResult(result)));
   } catch (err) {
     const msg = extractChaincodeError(err);
     res.status(400).json({ error: msg });
@@ -159,7 +165,7 @@ app.get('/api/products/:id', resolveOrg, async (req, res) => {
   try {
     const contract = await getContract(req.org);
     const result = await contract.evaluateTransaction('ReadProduct', req.params.id);
-    res.json(JSON.parse(result.toString()));
+    res.json(JSON.parse(decodeResult(result)));
   } catch (err) {
     const msg = extractChaincodeError(err);
     res.status(404).json({ error: msg });
@@ -171,7 +177,7 @@ app.get('/api/products/:id/history', resolveOrg, async (req, res) => {
   try {
     const contract = await getContract(req.org);
     const result = await contract.evaluateTransaction('GetHistory', req.params.id);
-    res.json(JSON.parse(result.toString()));
+    res.json(JSON.parse(decodeResult(result)));
   } catch (err) {
     const msg = extractChaincodeError(err);
     res.status(404).json({ error: msg });

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+const grpc = require('@grpc/grpc-js');
+const { connect, signers } = require('@hyperledger/fabric-gateway');
+const express = require('express');
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const PORT = process.env.PORT || 3000;
+const CHANNEL_NAME = process.env.CHANNEL_NAME || 'supplychannel';
+const CC_NAME = process.env.CC_NAME || 'product-trace';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TEST_NET_DIR = path.join(REPO_ROOT, 'fabric', 'fabric-samples', 'test-network');
+const ORGS_DIR = path.join(TEST_NET_DIR, 'organizations', 'peerOrganizations');
+
+const ORG_CONFIG = {
+  org1: { mspId: 'Org1MSP', peerEndpoint: 'localhost:7051', peerHostAlias: 'peer0.org1.example.com', label: 'メーカー A' },
+  org2: { mspId: 'Org2MSP', peerEndpoint: 'localhost:9051', peerHostAlias: 'peer0.org2.example.com', label: '卸 B' },
+  org3: { mspId: 'Org3MSP', peerEndpoint: 'localhost:11051', peerHostAlias: 'peer0.org3.example.com', label: '販売店 C' },
+};
+
+// ---------------------------------------------------------------------------
+// Fabric Gateway helpers
+// ---------------------------------------------------------------------------
+
+function findPrivateKey(keyDir) {
+  const files = fs.readdirSync(keyDir);
+  const skFile = files.find((f) => f.endsWith('_sk'));
+  if (!skFile) throw new Error(`No private key (*_sk) found in ${keyDir}`);
+  return path.join(keyDir, skFile);
+}
+
+function orgPaths(orgName) {
+  const n = orgName.replace('org', '');
+  const orgDomain = `org${n}.example.com`;
+  const peerOrg = path.join(ORGS_DIR, orgDomain);
+  return {
+    tlsCert: path.join(peerOrg, 'peers', `peer0.${orgDomain}`, 'tls', 'ca.crt'),
+    certPath: path.join(peerOrg, 'users', `Admin@${orgDomain}`, 'msp', 'signcerts', 'cert.pem'),
+    keyDir: path.join(peerOrg, 'users', `Admin@${orgDomain}`, 'msp', 'keystore'),
+  };
+}
+
+async function newGrpcConnection(orgName) {
+  const { tlsCert } = orgPaths(orgName);
+  const tlsRootCert = fs.readFileSync(tlsCert);
+  const tlsCredentials = grpc.credentials.createSsl(tlsRootCert);
+  const cfg = ORG_CONFIG[orgName];
+  return new grpc.Client(cfg.peerEndpoint, tlsCredentials, {
+    'grpc.ssl_target_name_override': cfg.peerHostAlias,
+  });
+}
+
+function newIdentity(orgName) {
+  const { certPath } = orgPaths(orgName);
+  const credentials = fs.readFileSync(certPath);
+  return { mspId: ORG_CONFIG[orgName].mspId, credentials };
+}
+
+function newSigner(orgName) {
+  const { keyDir } = orgPaths(orgName);
+  const keyPath = findPrivateKey(keyDir);
+  const privateKeyPem = fs.readFileSync(keyPath);
+  const privateKey = crypto.createPrivateKey(privateKeyPem);
+  return signers.newPrivateKeySigner(privateKey);
+}
+
+// Cache gateway connections per org
+const gatewayCache = {};
+
+async function getGateway(orgName) {
+  if (gatewayCache[orgName]) return gatewayCache[orgName];
+  const client = await newGrpcConnection(orgName);
+  const gateway = connect({
+    client,
+    identity: newIdentity(orgName),
+    signer: newSigner(orgName),
+    evaluateOptions: () => ({ deadline: Date.now() + 5000 }),
+    endorseOptions: () => ({ deadline: Date.now() + 15000 }),
+    submitOptions: () => ({ deadline: Date.now() + 5000 }),
+    commitStatusOptions: () => ({ deadline: Date.now() + 60000 }),
+  });
+  gatewayCache[orgName] = { gateway, client };
+  return { gateway, client };
+}
+
+async function getContract(orgName) {
+  const { gateway } = await getGateway(orgName);
+  const network = gateway.getNetwork(CHANNEL_NAME);
+  return network.getContract(CC_NAME);
+}
+
+// ---------------------------------------------------------------------------
+// Express App
+// ---------------------------------------------------------------------------
+
+const app = express();
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Org validation middleware
+function resolveOrg(req, res, next) {
+  const org = req.query.org || req.headers['x-org'] || 'org1';
+  if (!ORG_CONFIG[org]) {
+    return res.status(400).json({ error: `Invalid org: ${org}. Use org1, org2, or org3` });
+  }
+  req.org = org;
+  next();
+}
+
+// GET /api/orgs — list available orgs
+app.get('/api/orgs', (_req, res) => {
+  const orgs = Object.entries(ORG_CONFIG).map(([key, cfg]) => ({
+    key,
+    mspId: cfg.mspId,
+    label: cfg.label,
+  }));
+  res.json(orgs);
+});
+
+// POST /api/products — CreateProduct
+app.post('/api/products', resolveOrg, async (req, res) => {
+  try {
+    const { productId } = req.body;
+    if (!productId) return res.status(400).json({ error: 'productId is required' });
+    const contract = await getContract(req.org);
+    const mspId = ORG_CONFIG[req.org].mspId;
+    const result = await contract.submitTransaction('CreateProduct', productId, mspId, mspId);
+    res.json(JSON.parse(result.toString()));
+  } catch (err) {
+    const msg = extractChaincodeError(err);
+    res.status(400).json({ error: msg });
+  }
+});
+
+// POST /api/products/:id/transfer — TransferProduct
+app.post('/api/products/:id/transfer', resolveOrg, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { toOwner } = req.body;
+    if (!toOwner) return res.status(400).json({ error: 'toOwner is required' });
+    const contract = await getContract(req.org);
+    const fromOwner = ORG_CONFIG[req.org].mspId;
+    const result = await contract.submitTransaction('TransferProduct', id, fromOwner, toOwner);
+    res.json(JSON.parse(result.toString()));
+  } catch (err) {
+    const msg = extractChaincodeError(err);
+    res.status(400).json({ error: msg });
+  }
+});
+
+// GET /api/products/:id — ReadProduct
+app.get('/api/products/:id', resolveOrg, async (req, res) => {
+  try {
+    const contract = await getContract(req.org);
+    const result = await contract.evaluateTransaction('ReadProduct', req.params.id);
+    res.json(JSON.parse(result.toString()));
+  } catch (err) {
+    const msg = extractChaincodeError(err);
+    res.status(404).json({ error: msg });
+  }
+});
+
+// GET /api/products/:id/history — GetHistory
+app.get('/api/products/:id/history', resolveOrg, async (req, res) => {
+  try {
+    const contract = await getContract(req.org);
+    const result = await contract.evaluateTransaction('GetHistory', req.params.id);
+    res.json(JSON.parse(result.toString()));
+  } catch (err) {
+    const msg = extractChaincodeError(err);
+    res.status(404).json({ error: msg });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Error extraction
+// ---------------------------------------------------------------------------
+
+function extractChaincodeError(err) {
+  // fabric-gateway wraps chaincode errors in details
+  if (err.details && err.details.length > 0) {
+    for (const detail of err.details) {
+      if (detail.message) return detail.message;
+    }
+  }
+  // Fallback: try to extract from message string
+  const match = err.message && err.message.match(/message=(.+?)(?:,|$)/);
+  if (match) return match[1].trim();
+  return err.message || 'Unknown error';
+}
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+app.listen(PORT, () => {
+  console.log(`[web-demo] Server running at http://localhost:${PORT}`);
+  console.log(`[web-demo] Fabric channel=${CHANNEL_NAME} chaincode=${CC_NAME}`);
+});
+
+// Graceful shutdown
+process.on('SIGINT', () => {
+  console.log('\n[web-demo] Shutting down...');
+  for (const [org, cached] of Object.entries(gatewayCache)) {
+    try { cached.gateway.close(); } catch (_) {}
+    try { cached.client.close(); } catch (_) {}
+  }
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

- Express + @hyperledger/fabric-gateway による REST API サーバー（4 エンドポイント）
- 静的 HTML + vanilla JS のフロントエンド SPA（組織切替・製品登録・移転・来歴タイムライン）
- 起動スクリプト `scripts/web_demo.sh` と操作ガイド `docs/web-demo-guide.md`

Closes #5

## Test plan

- [x] L1 単体テスト 24/24 PASS（既存テスト非破壊）
- [x] E2E 正常系: N1 CreateProduct / N2 A→B / N3 B→C / N4 GetHistory — 全 PASS
- [x] E2E 異常系: E1 所有者偽装 / E2 未登録照会 / E3 重複登録 — 全 PASS
- [ ] ブラウザでの画面操作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)