### PR TITLE
feat(demo): Merge-of-Merge / Diamond DAG + 業務リアル portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,20 @@ Endorsement policy: `OR('Org1MSP.peer',...,'Org5MSP.peer')`
 ./scripts/network_up.sh
 ./scripts/deploy_chaincode.sh
 
-# 4. 複合シナリオ実行 (分割 → 接合 → 納品 → 系譜検証)
+# 4. 3 部構成デモ実行
+#    Part 1: 基本シナリオ (分割 → 接合 → 納品)
+#    Part 2: Merge-of-Merge (多段組立)
+#    Part 3: Diamond DAG (祖先再マージ)
 ./scripts/demo_normal.sh
 ```
 
 > 一括: `./scripts/demo_normal.sh --fresh` で reset → 起動 → デプロイ → デモまで連動。
+> 詳細台本: [docs/demo-scenarios.md](docs/demo-scenarios.md)
 
 **ブラウザ版デモ**: `./scripts/web_demo.sh` → `http://localhost:3000`
 - 5 組織切替 / 新規素材登録 (ミルシート PDF ドロップで SHA-256 自動計算)
 - 分割・接合フォーム / Mermaid による系譜 DAG 可視化
+- サンプル素材の冪等投入: `./scripts/demo_seed.sh` (単純 DAG + Merge-of-Merge + Diamond DAG を含む)
 
 クリーンアップ: `./scripts/reset.sh --yes`
 

--- a/docs/demo-scenarios.md
+++ b/docs/demo-scenarios.md
@@ -1,6 +1,8 @@
-# デモシナリオ詳細
+# デモシナリオ詳細 (v2 / 5Org)
 
-`spec.md` §9 のシナリオ N1〜N4 / E1〜E3 を、デモ担当者が **実演しながら語れる** 粒度に展開したもの。正常系 → C 視点クライマックス → 異常系の 3 段構成で実測 5〜7 分（invoke 1 回 3〜6 秒 × 複数 + pause を含む）。
+`spec-v2.md` のシナリオを、デモ担当者が **実演しながら語れる** 粒度に展開したもの。3 部の正常系 + 拡張異常系で実測 10〜12 分（invoke 1 回 3〜6 秒 × 複数 + pause）。
+
+> v1 (3Org A/B/C 譲渡のみ) のシナリオは git 履歴 (tag `phase6-done`) を参照。本ドキュメントは v2 (5Org + Split/Merge) 現行版。
 
 ---
 
@@ -8,27 +10,23 @@
 
 - [前提](#前提)
 - [登場人物と語彙対応](#登場人物と語彙対応)
-- [全体フロー（5 分構成）](#全体フロー5-分構成)
-- [正常系シナリオ](#正常系シナリオ)
-  - [N1: 製品登録](#n1-製品登録)
-  - [N2: A → B 移転](#n2-a--b-移転)
-  - [N3: B → C 移転](#n3-b--c-移転)
-  - [N4: C による履歴確認](#n4-c-による履歴確認)
-- [C 視点クライマックス](#c-視点クライマックス)
+- [全体フロー](#全体フロー)
+- [Part 1: 基本シナリオ（製造 → 分割 → 接合 → 納品）](#part-1-基本シナリオ製造--分割--接合--納品)
+- [Part 2: Merge-of-Merge（多段組立）](#part-2-merge-of-merge多段組立)
+- [Part 3: Diamond DAG（祖先再マージ）](#part-3-diamond-dag祖先再マージ)
+- [Web UI 向けサンプル投入（demo_seed.sh）](#web-ui-向けサンプル投入demo_seedsh)
 - [異常系シナリオ](#異常系シナリオ)
-  - [E1: 所有者偽装](#e1-所有者偽装)
-  - [E2: 未登録製品の照会](#e2-未登録製品の照会)
-  - [E3: 重複登録](#e3-重複登録)
+- [エラーコード一覧](#エラーコード一覧)
 - [口頭ナレーション（30 秒 スコープ説明）](#口頭ナレーション30-秒-スコープ説明)
-- [スコープ外（このデモが扱わないこと）](#スコープ外このデモが扱わないこと)
+- [スコープ外](#スコープ外)
 
 ---
 
 ## 前提
 
-- ネットワーク起動 + chaincode デプロイ済み（[`README.md`](../README.md#セットアップ手順) 参照）
+- 5Org ネットワーク起動 + chaincode デプロイ済み（[`README.md`](../README.md#quick-start) 参照）
 - 画面は 1 枚のターミナルで完結。事前に `./scripts/reset.sh --yes && ./scripts/network_up.sh && ./scripts/deploy_chaincode.sh` を済ませておく
-- または `./scripts/demo_normal.sh --fresh` でクリーン状態から一括実行可能
+- または `./scripts/demo_normal.sh --fresh` でクリーン状態から Part 1〜3 を一括実行可能
 
 ---
 
@@ -36,210 +34,280 @@
 
 | 業務語彙 | MSP ID | 役割 | chaincode 権限 |
 |---|---|---|---|
-| メーカー A | `Org1MSP` | 製造元 | `CreateProduct` 可 |
-| 卸 B | `Org2MSP` | 中間流通 | `TransferProduct`（現所有者時） |
-| 販売店 C | `Org3MSP` | 最終販売 | `TransferProduct`（現所有者時） / 履歴照会 |
+| 高炉メーカー A | `Org1MSP` | 鋼板を製造 | `CreateProduct` 可 |
+| 電炉メーカー X | `Org2MSP` | 形鋼を製造 | `CreateProduct` 可 |
+| 加工業者 B     | `Org3MSP` | 切断・接合 | `Split` / `Merge`（現所有者時） |
+| 加工業者 Y     | `Org4MSP` | 切断・接合 | `Split` / `Merge`（現所有者時） |
+| 建設会社 D     | `Org5MSP` | 最終納品先・系譜の検証者 | 閲覧のみ |
 
-内部 MSP ID は fabric-samples 標準の `Org1MSP`/`Org2MSP`/`Org3MSP` を使用し、表示層 `scripts/lib/format.sh` で業務語彙に変換する。
+内部 MSP ID は fabric-samples 標準の `Org1MSP`〜`Org5MSP`。表示層 `scripts/lib/format.sh` の `msp_to_role` で業務語彙に変換する。
+
+Endorsement Policy: `OR('Org1MSP.peer','Org2MSP.peer','Org3MSP.peer','Org4MSP.peer','Org5MSP.peer')`
 
 ---
 
-## 全体フロー（実測 5〜7 分構成）
+## 全体フロー
 
 | 時間（目安） | フェーズ | スクリプト | 目的 |
 |---|---|---|---|
-| 0:00–0:30 | 課題提起 / 登場人物 | `demo_normal.sh` 冒頭ナレーション | 「なぜ必要か」を共有 |
-| 0:30–2:30 | 正常系 N1〜N3 | `demo_normal.sh` | A→B→C の譲渡を台帳に記録 |
-| 2:30–4:00 | C 視点クライマックス | `demo_verify_as_c.sh` | 起点 A を C の立場で証明 |
-| 4:00–6:00 | 異常系 E1〜E3 | `demo_error.sh` | 「書けないはずのものは書けない」 |
-| 6:00–6:30 | スコープと限界 | 口頭ナレーション | 物理真正性は別論点（後述） |
+| 0:00–1:00 | 課題提起 / 登場人物 | `demo_normal.sh` 冒頭 | 「なぜ必要か」を共有 |
+| 1:00–3:30 | Part 1 基本シナリオ | `demo_normal.sh` (N1-N7) | 分割・接合・起点検証の基本動作 |
+| 3:30–7:00 | Part 2 Merge-of-Merge | `demo_normal.sh` (P2-1〜P2-11) | 多段組立の DAG 表現 |
+| 7:00–9:00 | Part 3 Diamond DAG | `demo_normal.sh` (P3-1〜P3-5) | 祖先再マージでも循環が起きないこと |
+| 9:00–11:00 | 異常系 E1〜E5 | `demo_error.sh` | 「書けないはずのものは書けない」 |
+| 11:00–12:00 | スコープと限界 | 口頭ナレーション | 物理真正性は別レイヤー |
 
-※ invoke は 1 回あたり 3〜6 秒（endorsement + ordering + commit）。PC 性能や `DEMO_PAUSE` 環境変数で上下するため、Phase 7 のクリーン VM リハで実測校正すること。
+※ invoke は 1 回あたり 3〜6 秒（endorsement + ordering + commit）。PC 性能や `DEMO_PAUSE` 環境変数で上下する。
 
 ---
 
-## 正常系シナリオ
+## Part 1: 基本シナリオ（製造 → 分割 → 接合 → 納品）
 
-### N1: 製品登録
+**狙い**: 2 系統メーカー (A/X) の鋼材を 1 つの部材に接合し、建設会社 D が起点まで遡れる最小フローを示す。
 
-**語り**: 「メーカー A が出荷前の最終工程で、製品 `X001` を台帳に登録します。登録できるのは A だけ。他社が A を騙ることは chaincode 層で拒否されます。」
+### N1/N2: 鋼板 S1 (A) と形鋼 S2 (X) を製造
 
 **コマンド**:
 ```bash
-./scripts/invoke_as.sh org1 invoke CreateProduct X001 Org1MSP Org1MSP
+./scripts/invoke_as.sh org1 invoke CreateProduct "${S1}" Org1MSP Org1MSP \
+  '{"category":"plate","grade":"SS400","weightKg":10000,"heatNo":"HT-A01"}' "" ""
+./scripts/invoke_as.sh org2 invoke CreateProduct "${S2}" Org2MSP Org2MSP \
+  '{"category":"shape","grade":"SM490","weightKg":2000,"heatNo":"HT-X01"}' "" ""
+```
+
+**検証ポイント**:
+- `manufacturer == caller MSP` が必須（`INITIAL_OWNER_MISMATCH` で他社 Create は弾かれる）
+- manufacturer フィールドは以降不変
+- ミルシート (SHA-256 + URI) は optional 引数（空文字で省略可）
+
+### N3: S1/S2 を加工業者 B に集約
+
+`TransferProduct` を A/X の credential で呼ぶ。`fromOwner = caller MSP = currentOwner` の三点照合が通る。
+
+### N4: 加工業者 B が S1 を 3 分割
+
+**コマンド**:
+```bash
+./scripts/invoke_as.sh org3 invoke SplitProduct "${S1}" \
+  '[{"childId":"S1-a","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":3000}"},
+    {"childId":"S1-b","toOwner":"Org5MSP","metadataJson":"{\"weightKg\":3000}"},
+    {"childId":"S1-c","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":4000}"}]'
+```
+
+**検証ポイント**:
+- **親 S1 は ACTIVE のまま** （v1.3 以降の「切り出し」モデル）
+- `parent.children` に `[S1-a, S1-b, S1-c]` が追記される（ソート済み）
+- 子 3 つはそれぞれ独立した state entry として生成
+- 子 1 (`S1-b`) は toOwner=Org5MSP で直送（建設 D に直接渡る）
+
+### N5: B が S1-a + S2 を接合 → P1（柱材）
+
+**コマンド**:
+```bash
+./scripts/invoke_as.sh org3 invoke MergeProducts '["S1-a","S2"]' \
+  '{"childId":"P1","metadataJson":"{\"type\":\"welded\",\"purpose\":\"柱\"}"}'
+```
+
+**検証ポイント**:
+- 全親が ACTIVE かつ caller 所有（`PARENTS_OWNER_DIVERGENT` / `PARENT_NOT_ACTIVE` を回避）
+- 親 2 つは **CONSUMED に遷移**（Merge は親を消費する）
+- 子 P1 の `parents = [S1-a, S2]`, `manufacturer = Org3MSP`（接合実施者）
+
+### N6: P1 を建設 D に納品
+
+TransferProduct で Org3MSP → Org5MSP。
+
+### N7: 建設 D が P1 の系譜を検証
+
+**コマンド**:
+```bash
+./scripts/invoke_as.sh org5 query GetLineage P1
 ```
 
 **期待結果（整形後）**:
 ```
-productId    : X001
-manufacturer : メーカー A (Org1MSP)
-currentOwner : メーカー A (Org1MSP)
-status       : ACTIVE
-createdAt    : 2026-04-15T09:00:00.000Z
-updatedAt    : 2026-04-15T09:00:00.000Z
+nodes:
+  P1     manufacturer=Org3MSP  owner=Org5MSP  status=ACTIVE
+  S1-a   manufacturer=Org1MSP  owner=Org3MSP  status=CONSUMED
+  S2     manufacturer=Org2MSP  owner=Org3MSP  status=CONSUMED
+  S1     manufacturer=Org1MSP  owner=Org3MSP  status=ACTIVE
+edges:
+  S1   ─SPLIT→ S1-a
+  S1-a ─MERGE→ P1
+  S2   ─MERGE→ P1
 ```
 
-**検証ポイント**:
-- `currentOwner == Org1MSP`
-- `manufacturer == Org1MSP`（以降不変）
-- `createdAt == updatedAt`（登録時は同時刻）
-- timestamp は `ctx.stub.getTxTimestamp()` 由来（全 endorser で同一）
+→ 起点が高炉 A (S1) と電炉 X (S2) の **2 系統** として可視化される。
 
 ---
 
-### N2: A → B 移転
+## Part 2: Merge-of-Merge（多段組立）
 
-**語り**: 「A が出荷し、卸 B に所有権が移ります。`fromOwner` を A、`toOwner` を B として TransferProduct を呼びます。chaincode は現所有者 = fromOwner = 呼び出し主体 を三点照合します。」
+**狙い**: 「親自身が前段 Merge の結果」という入れ子パターンでも DAG が正しく育つことを示す。実務では小組 → 本体組 → 最終組立と段階加工する現実的パターン。
 
-**コマンド**:
+### フロー概要
+
+```mermaid
+flowchart LR
+  S3[S3: 2t SM490 X製] -->|Split| S3A[S3-a 1.2t]
+  S3A -->|Split| S3A1[S3-a-1 0.5t]
+  S3 -->|Split| S3B[S3-b 0.8t]
+  S3A1 -->|Merge| PY[PY: Y 小組]
+  S3B -->|Merge| PY
+  PY -->|Transfer Y→B| PY2[PY at B]
+
+  S4[S4: 8t SS400 A製] -->|Split| S4X[S4-x 3t]
+  S4 -->|Split| S4Y[S4-y 5t]
+  S4X -->|Merge| PB[PB: B 本体組]
+  S4Y -->|Merge| PB
+
+  PB -->|Merge| PF[PF: 最終組立]
+  PY2 -->|Merge| PF
+  PF -->|Transfer B→D| PF2[PF at D]
+```
+
+### P2-1 〜 P2-5: 加工 Y が小組ユニット PY を作り B に譲渡
+
+1. 電炉 X が S3 (形鋼 2t) を製造 → Y へ譲渡
+2. Y が S3 を 2 分割 → S3-a (1.2t), S3-b (0.8t)
+3. Y が S3-a をさらに切り出し → S3-a-1 (0.5t) + S3-a は ACTIVE 継続
+4. Y が S3-a-1 + S3-b を Merge → PY (Y 内製小組)
+5. PY を Y→B に Transfer（**cross-fabricator**: 他組織の Merge 結果を受け取る）
+
+### P2-6 〜 P2-10: 加工 B が本体組 PB を作り、PB + PY を最終接合
+
+6. 高炉 A が S4 (鋼板 8t) を製造 → B へ譲渡
+7. B が S4 を 2 分割 → S4-x (3t), S4-y (5t)
+8. B が S4-x + S4-y を Merge → PB
+9. **B が PB + PY を Merge → PF**（← Merge-of-Merge: 両親とも前段 Merge の結果）
+10. PF を B→D に納品
+
+### P2-11: 建設 D が PF の系譜を検証
+
+`GetLineage PF` の結果で確認すべき点:
+- nodes に S4, S3 (最上流の製造物) が含まれる
+- edges に `PB ─MERGE→ PF`, `PY ─MERGE→ PF` の両方が出る
+- 深さは最大 4 階層（PF → PY → S3-a-1 → S3-a → S3）
+
+→ **親が Merge 結果でも通常の製造物でも、Lineage 走査は同じロジックで動く**。chaincode 側の分岐は parents.length の 0 / 1 / ≥2 のみ。
+
+---
+
+## Part 3: Diamond DAG（祖先再マージ）
+
+**狙い**: ある素材を切り出して加工し、その結果を元の素材に戻して接合する ── という実務パターンでも、DAG として整合が保たれることを示す。
+
+### フロー概要
+
+```mermaid
+flowchart TD
+  S5[S5: 6t SS400]
+  S5 -->|Split| S5P[S5-p 2t]
+  S5P -->|Split| S5P1[S5-p-1 1t]
+  S5 -.->|Merge 直接親| PD[PD: Diamond]
+  S5P1 -.->|Merge 直接親| PD
+```
+
+### P3-1 〜 P3-4: 切り出し 2 段 + 祖先再マージ
+
+1. 高炉 A が S5 (鋼板 6t) を製造 → B へ譲渡
+2. B が S5 から S5-p (2t) を切り出し（S5 は ACTIVE 継続）
+3. B が S5-p から S5-p-1 (1t) をさらに切り出し（S5-p も ACTIVE 継続）
+4. **B が S5 + S5-p-1 を Merge → PD**（祖先と子孫の再マージ）
+
+### P3-5: Diamond DAG を GetLineage で確認
+
+`GetLineage PD` で edges を見ると:
+```
+S5    ─MERGE→ PD      (直接)
+S5    ─SPLIT→ S5-p    (祖先経路1)
+S5-p  ─SPLIT→ S5-p-1  (祖先経路2)
+S5-p-1 ─MERGE→ PD     (直接)
+```
+
+→ **S5 への入エッジが 2 本**見える（直接 / 孫経由）。これがダイヤモンド型 DAG。
+
+### 設計上の論点
+
+- chaincode は「親が他の親の祖先に含まれる」かの検査をしない（Merge 時の祖先 walk は O(depth) で endorsement コストが増すため）
+- 構造的には**循環は不可能**（新規 product は必ず既存より後に作成される = 位相順序あり）
+- 「D の物質はどれだけ S5 由来か」を **経路本数で重み付けする集計は誤る**（集合として S5 を含むと判定するのが正しい）
+- 業務上禁止したければ Web UI 側で警告する運用が現実的
+
+---
+
+## Web UI 向けサンプル投入（demo_seed.sh）
+
+`./scripts/demo_seed.sh` を走らせると、上記 Part 1〜3 と同じパターンの素材を異なる productId (S-A-001 系 / P-B-020 / P-B-040 など) で冪等投入する。
+
+投入後の手持ち素材一覧:
+
+| 組織 | 確認コマンド | 内容 |
+|---|---|---|
+| 加工 B | `./scripts/invoke_as.sh org3 query ListProductsByOwner Org3MSP` | S-A-001 系の残り / P-B-002 / P-B-040 等 |
+| 加工 Y | `./scripts/invoke_as.sh org4 query ListProductsByOwner Org4MSP` | S-X-002, S-X-004 系の残り |
+| 建設 D | `./scripts/invoke_as.sh org5 query ListProductsByOwner Org5MSP` | S-A-001-b / P-B-001 / P-B-020 |
+
+系譜検証:
 ```bash
-./scripts/invoke_as.sh org1 invoke TransferProduct X001 Org1MSP Org2MSP
+./scripts/invoke_as.sh org5 query GetLineage P-B-020    # Merge-of-Merge DAG
+./scripts/invoke_as.sh org3 query GetLineage P-B-040    # Diamond DAG
 ```
-
-**期待結果**:
-```
-productId    : X001
-manufacturer : メーカー A (Org1MSP)
-currentOwner : 卸 B (Org2MSP)
-status       : ACTIVE
-updatedAt    : 2026-04-15T09:05:00.000Z   ← 更新
-```
-
-**検証ポイント**:
-- `currentOwner == Org2MSP`
-- `manufacturer` は変わらず `Org1MSP`
-- `updatedAt` のみ更新
-
----
-
-### N3: B → C 移転
-
-**語り**: 「さらに卸 B が販売店 C に譲渡します。今度は B の credential で invoke しないと通りません。A が代理実行することはできない。」
-
-**コマンド**:
-```bash
-./scripts/invoke_as.sh org2 invoke TransferProduct X001 Org2MSP Org3MSP
-```
-
-**期待結果**:
-```
-currentOwner : 販売店 C (Org3MSP)
-updatedAt    : 2026-04-15T09:10:00.000Z
-```
-
----
-
-### N4: C による履歴確認
-
-**語り**: 「C の手元の台帳から履歴を取得します。C は自組織 peer に問い合わせているので、A や B の言い分を信用する必要がありません。」
-
-**コマンド**:
-```bash
-./scripts/invoke_as.sh org3 query GetHistory X001
-```
-
-**期待結果（整形後）**:
-```
-#1 CREATE    by メーカー A (Org1MSP)
-    at   : 2026-04-15T09:00:00.000Z
-    txId : a1b2c3...
-
-#2 TRANSFER  by メーカー A (Org1MSP)   Org1MSP → Org2MSP
-    at   : 2026-04-15T09:05:00.000Z
-    txId : d4e5f6...
-
-#3 TRANSFER  by 卸 B    (Org2MSP)   Org2MSP → Org3MSP
-    at   : 2026-04-15T09:10:00.000Z
-    txId : 7890ab...
-```
-
-**検証ポイント**:
-- 3 件が時系列順
-- `#1.eventType == "CREATE"` かつ `#1.actor.mspId == Org1MSP` → **起点 A の証明**
-- 各イベントに `txId` が付与されており後から同じ block を参照可能
-- GetHistoryForKey は state 変遷のスナップショット列を返す（詳細: [`fabric-pitfalls.md`](fabric-pitfalls.md) §GetHistoryForKey）
-
----
-
-## C 視点クライマックス
-
-**スクリプト**: `./scripts/demo_verify_as_c.sh`（引数省略時は `demo_normal.sh` が書いた `.last_product_id` を自動取得）
-
-**語り**:
-> 「販売店 C のカウンターに商品 `X001` が並んでいる。流通過程で差し替わっていないか？ C は A や B に問い合わせる必要はなく、自組織 `Org3MSP` のクレデンシャルで、自組織 peer に履歴を尋ねるだけでよい。
->
-> 結果 ── #1 のイベントは `CREATE`、実行主体は `Org1MSP` = メーカー A。その後 B を経由し、C の手元に届いた。**この履歴は B や C の主張ではなく、3 社のネットワーク全体で合意・承認されたもの** だ。」
-
-**強調すべき点**:
-- C は誰かを信用する必要がない（trust-minimized）
-- `#1.actor.mspId == Org1MSP` を条件に「起点 A である」を機械判定できる
-- 改ざんしようとすれば chaincode の所有者照合 or endorsement policy で弾かれる
 
 ---
 
 ## 異常系シナリオ
 
-### E1: 所有者偽装
+`demo_error.sh` と手動実行で実演できる 5 パターン。全て `throw new Error('[CODE] ...')` で endorsement failure を誘発し、block には載らない。
 
-**攻撃者シナリオ**: 販売店 C が「これは直前まで B が持っていた product だ」と嘘の由来を主張し、B→C の移転を自分の Credential で書き込もうとする。
+### E1: 所有者偽装（OWNER_MISMATCH）
 
-**コマンド**:
+現所有者ではない MSP が `fromOwner` を詐称して Transfer を試みる。
+
 ```bash
 ./scripts/invoke_as.sh org3 invoke TransferProduct X001 Org2MSP Org3MSP
+# → [OWNER_MISMATCH] fromOwner does not match currentOwner
 ```
 
-**期待結果**:
-```
-Error: endorsement failure during invoke.
-response: status:500 message:"[OWNER_MISMATCH] fromOwner does not match currentOwner: from=Org2MSP, current=Org3MSP"
-```
+### E2: 未登録製品の照会（PRODUCT_NOT_FOUND）
 
-**検証二段構え**:
-1. exit code ≠ 0、`[OWNER_MISMATCH]` エラーコードが付与されている
-2. 直後に `GetHistory X001` を再実行し、履歴に新規イベントが追加されていないこと
-
-**chaincode ロジック**: `TransferProduct` は (a) `product.currentOwner !== fromOwner` で `[OWNER_MISMATCH]`、(b) `ctx.clientIdentity.getMSPID() !== fromOwner` で `[MSP_NOT_AUTHORIZED]` を順に検査する。E1 は N フロー完了後 (currentOwner=Org3MSP) に C が `fromOwner=Org2MSP` と偽るため (a) が先に発火する。throw により endorsement failure となり block には載らない。
-
----
-
-### E2: 未登録製品の照会
-
-**語り**: 「偽の追跡番号を投げられても、chaincode は静かに成功を返さない。」
-
-**コマンド**:
 ```bash
 ./scripts/invoke_as.sh org3 query ReadProduct GHOST-001
+# → [PRODUCT_NOT_FOUND] productId=GHOST-001
 ```
 
-**期待結果**:
-```
-Error: [PRODUCT_NOT_FOUND] productId=GHOST-001
-```
+### E3: 重複登録（PRODUCT_ALREADY_EXISTS）
 
-**検証ポイント**:
-- 読み取り専用なので副作用なし（履歴の汚染が原理的に発生しない）
-- エラーコードが明示的で、UI 側でユーザ向けメッセージへ変換可能
+既存 productId を再度 CreateProduct する。
 
----
-
-### E3: 重複登録
-
-**攻撃者シナリオ**: 既存の `X001` と同じ productId で CreateProduct を再実行し、履歴の分岐を起こして起点を曖昧にしようとする。
-
-**コマンド**:
 ```bash
-./scripts/invoke_as.sh org1 invoke CreateProduct X001 Org1MSP Org1MSP
+./scripts/invoke_as.sh org1 invoke CreateProduct X001 Org1MSP Org1MSP "" "" ""
+# → [PRODUCT_ALREADY_EXISTS] productId=X001
 ```
 
-**期待結果**:
-```
-Error: endorsement failure ...
-message:"[PRODUCT_ALREADY_EXISTS] productId=X001"
+### E4: CONSUMED 親の再利用（PARENT_NOT_ACTIVE）← v2 で追加
+
+Merge 済みの親（CONSUMED）を再度 Split / Merge しようとする。
+
+```bash
+# P1 作成時に CONSUMED になった S1-a を再度 Merge しようとする
+./scripts/invoke_as.sh org3 invoke MergeProducts '["S1-a","S1-c"]' \
+  '{"childId":"P2","metadataJson":"{}"}'
+# → [PARENT_NOT_ACTIVE] parent is not ACTIVE (status=CONSUMED)
 ```
 
-**検証二段構え**:
-1. exit code ≠ 0、`[PRODUCT_ALREADY_EXISTS]` エラーコード
-2. `GetHistory X001` で既存 3 件（CREATE / TRANSFER / TRANSFER）のまま。重複 CREATE は追加されない
+### E5: 所有者分散 Merge（PARENTS_OWNER_DIVERGENT）← v2 で追加
+
+Merge 対象の複数親を caller が全部所有していない状態で実行する。
+
+```bash
+# B が S1-a (B 所有) と S3 (Y 所有) を Merge しようとする
+./scripts/invoke_as.sh org3 invoke MergeProducts '["S1-a","S3"]' \
+  '{"childId":"PX","metadataJson":"{}"}'
+# → [PARENTS_OWNER_DIVERGENT] parent currentOwner must equal caller
+```
+
+→ 正しい運用: 先に Transfer で caller 所有に集約してから Merge する（Part 2 の P2-5 で実演）。
 
 ---
 
@@ -247,10 +315,17 @@ message:"[PRODUCT_ALREADY_EXISTS] productId=X001"
 
 | コード | 発生条件 | 対応 chaincode 関数 |
 |---|---|---|
-| `[OWNER_MISMATCH]` | 呼び出し主体 ≠ 現所有者 / fromOwner | `TransferProduct` |
-| `[PRODUCT_NOT_FOUND]` | 指定 productId が未登録 | `ReadProduct` / `TransferProduct` / `GetHistory` |
-| `[PRODUCT_ALREADY_EXISTS]` | 既存 productId に CreateProduct | `CreateProduct` |
+| `[INVALID_ARGUMENT]` | 引数不足 / JSON parse 失敗 / MSP ID 不正 | 全関数 |
+| `[MSP_NOT_AUTHORIZED]` | 呼び出し主体 MSP が権限条件を満たさない | `CreateProduct` / `TransferProduct` / `SplitProduct` |
 | `[INITIAL_OWNER_MISMATCH]` | 登録主体 ≠ initialOwner | `CreateProduct` |
+| `[PRODUCT_NOT_FOUND]` | 指定 productId が未登録 | `ReadProduct` / `TransferProduct` / `SplitProduct` / `GetHistory` / `GetLineage` |
+| `[PRODUCT_ALREADY_EXISTS]` | 既存 productId に CreateProduct | `CreateProduct` |
+| `[CHILD_ALREADY_EXISTS]` | Split/Merge の childId が既存または重複 | `SplitProduct` / `MergeProducts` |
+| `[OWNER_MISMATCH]` | 呼び出し主体 ≠ 現所有者 / fromOwner | `TransferProduct` |
+| `[PARENT_NOT_ACTIVE]` | Split/Merge 対象の親が CONSUMED | `SplitProduct` / `MergeProducts` / `TransferProduct` |
+| `[PARENTS_OWNER_DIVERGENT]` | Merge の親が caller 以外に所有されている | `MergeProducts` |
+| `[LINEAGE_DEPTH_EXCEEDED]` | 祖先 DAG の深さが 20 を超える | `GetLineage` |
+| `[INVALID_METADATA]` | metadata が object でない / JSON 不正 | `CreateProduct` / `SplitProduct` / `MergeProducts` |
 
 全て `throw new Error('[CODE] ...')` で endorsement failure を誘発する形式。詳細は [`fabric-pitfalls.md`](fabric-pitfalls.md) §chaincode エラーは message 本文しか伝搬しない 参照。
 
@@ -262,45 +337,53 @@ message:"[PRODUCT_ALREADY_EXISTS] productId=X001"
 
 > **このデモが示すのは「台帳に載った情報は改ざんされない」ことです。**
 >
+> 鋼材は分割・接合の多段加工を経て建設現場に届きます。台帳には各操作で parents/children の関係が自動記録され、建設会社はいつでも起点メーカーまでの DAG を辿れます。Merge-of-Merge や Diamond DAG のような複雑形状でも、循環せず一貫性が保たれます。
+>
 > 逆に言えば、台帳に載せる前 ── **モノ自体の真正性** ── は別レイヤーの論点になります。
 >
 > - 現物のすり替え
 > - 偽タグの貼付
-> - productId と物理製品の紐付けズレ
+> - productId と物理鋼材の紐付けズレ
 >
-> これらは QR コード / RFID / IoT センサー / 真正品判定デバイスなど、物理世界側の仕組みと組み合わせて補う前提です。
+> これらは QR コード / RFID / IoT センサー / ミルシート PDF の SHA-256 照合など、物理世界側の仕組みと組み合わせて補う前提です。
 >
-> 本 PoC はあくまで **組織間で譲渡履歴を共有・検証する部分** を扱います。台帳への入力が正しいことを前提に、入力後の一貫性・改ざん困難性を保証する層です。
+> 本 PoC はあくまで **組織間で譲渡・加工履歴を共有・検証する部分** を扱います。
 
 ---
 
-## スコープ外（このデモが扱わないこと）
+## スコープ外
 
-`spec.md` §3.2 および §16 に基づく非対象領域。デモ中に質問された場合の回答テンプレート:
+`spec-v2.md` §非対象領域に基づく。デモ中に質問された場合の回答テンプレート:
 
 ### 物理真正性は保証しない（最重要）
 
-**保証する**: 台帳上の来歴の一貫性、参加者間で共有された記録の改ざん困難性
+**保証する**: 台帳上の来歴（分割・接合を含む）の一貫性、参加者間で共有された記録の改ざん困難性
 
-**保証しない**: 現実世界の物理製品が本当に当該 productId に対応していること
+**保証しない**: 現実世界の物理鋼材が本当に当該 productId に対応していること
 
-具体的に別論点となるもの:
-
-- **QR コード貼付** — シールを剥がして別商品に貼り替える攻撃には無力
+- **QR コード貼付** — シールを剥がして別鋼材に貼り替える攻撃には無力
 - **RFID タグ** — タグ自体の複製 / リーダー側での入力改ざん
 - **IoT センサー連携** — センサーデータの真正性は別途担保が必要
-- **真正品判定デバイス** — 現物と productId の 1:1 対応を保証する仕組み
+- **ミルシート PDF** — 記録されるのは SHA-256 と URI のみ。PDF そのものの差し替えは別途検知必要
 
-これらは将来拡張の論点として `spec.md` §17 に記載。
+### 質量保存則は未検証
+
+`Split A (10t) → [B(3t), C(3t), D(4t)]` のような重量の整合性を chaincode は検証しない。
+`B(3t) + C(5t) → P(100t)` と宣言しても通る。metadata の `weightKg` は参考値として記録するのみ。
+業務ルール層（Web UI / 外部 ERP 連携）で実装する前提。
+
+### GetLineage の深さ上限
+
+`LINEAGE_MAX_DEPTH = 20` で打ち切り（`[LINEAGE_DEPTH_EXCEEDED]`）。
+無限ループ防御と endorsement コスト上限のため。20 段以上の多段加工を扱う業種では要見直し。
 
 ### その他の非対象
 
-- 本番運用向けの可用性設計 / HA（Raft 単一ノード orderer のため）
+- 本番運用向けの HA（Raft 単一 orderer のため）
 - 大規模性能試験
 - 外部 ERP / 在庫管理システムとの本格連携
 - 高度な秘密計算 / プライバシー強化技術の統合
-- Web UI / 可視化（CLI のみ）
-- Fabric CA 発行の end-user cert による認可（現状は Admin MSP 固定）
+- Fabric CA 発行の end-user cert による細粒度認可（現状は Admin MSP 固定）
 
 ---
 
@@ -308,17 +391,19 @@ message:"[PRODUCT_ALREADY_EXISTS] productId=X001"
 
 | 想定質問 | 回答要旨 |
 |---|---|
-| 「誰が書き換えを試みても止まるの？」 | chaincode の所有者照合 + endorsement policy (OR 3Org) の 2 段で止まる。E1 が実演例 |
-| 「1 社だけが嘘をついたら？」 | 本 PoC の OR ポリシーでは endorser 1 peer の承認で block に載り得るが、**その前段で chaincode 内の所有者照合 (`ctx.clientIdentity.getMSPID()` と現所有者/fromOwner の一致)** が決定的な防御線となる。嘘の invoke は自組織 peer であっても chaincode ロジック段で `[OWNER_MISMATCH]` となり endorsement failure で block に載らない。本番運用では `AND(Org1.peer, Org2.peer)` 等へポリシー自体を厳格化し二重防御にする |
-| 「QR コードを貼り替えられたら？」 | **台帳の外の話** 。上述「物理真正性は保証しない」を参照 |
+| 「誰が書き換えを試みても止まるの？」 | chaincode の所有者 / status 検査 + endorsement policy の 2 段で止まる。E1/E4/E5 が実演例 |
+| 「QR コードを貼り替えられたら？」 | **台帳の外の話**。上述「物理真正性は保証しない」を参照 |
+| 「1 社だけが嘘をついたら？」 | OR ポリシーでも chaincode 内の所有者検査 (`ctx.clientIdentity.getMSPID()` と現所有者の一致) が決定的な防御。本番運用では `AND` 化で二重防御 |
+| 「祖先を再 Merge したときに無限ループしないか？」 | Part 3 で実演。構造的に循環は不可能。`LINEAGE_MAX_DEPTH=20` で物理的な長さ上限も担保 |
+| 「重量が合わないまま台帳に載せたら？」 | 載る（chaincode は検証しない）。これは業務ルール層 / 物理計測装置で担保する設計判断 |
 | 「本番でも使える？」 | いいえ、PoC。HA / 性能 / CA 運用 / キー管理などは別途設計必要 |
-| 「historic query は誰でもできる？」 | 本 PoC ではチャンネル参加者全員が可。本番では Private Data Collection 等で閲覧制御可能 |
 
 ---
 
 ## 関連ドキュメント
 
 - [`README.md`](../README.md) — セットアップ・コマンドリファレンス
-- [`spec.md`](spec.md) — 機能仕様（凍結）
+- [`spec-v2.md`](spec-v2.md) — 機能仕様 (v2 現行)
 - [`architecture.md`](architecture.md) — 構成図
+- [`web-demo-guide.md`](web-demo-guide.md) — Web UI 手順
 - [`fabric-pitfalls.md`](fabric-pitfalls.md) — 実装時の落とし穴集

--- a/docs/demo-scenarios.md
+++ b/docs/demo-scenarios.md
@@ -238,18 +238,38 @@ S5-p-1 ─MERGE→ PD     (直接)
 
 ## Web UI 向けサンプル投入（demo_seed.sh）
 
-`./scripts/demo_seed.sh` を走らせると、上記 Part 1〜3 と同じパターンの素材を異なる productId (S-A-001 系 / P-B-020 / P-B-040 など) で冪等投入する。
+`./scripts/demo_seed.sh` を走らせると、上記 Part 1〜3 と同じパターンの素材を異なる productId (S-A-001 系 / P-B-020 / P-B-040 など) で冪等投入する。加えて **各社の手持ちが業務的にリアルな portfolio** になるよう、以下のカテゴリも投入される。
 
-投入後の手持ち素材一覧:
+### 投入される素材のカテゴリ
 
-| 組織 | 確認コマンド | 内容 |
+| カテゴリ | 意図 | 例 |
 |---|---|---|
-| 加工 B | `./scripts/invoke_as.sh org3 query ListProductsByOwner Org3MSP` | S-A-001 系の残り / P-B-002 / P-B-040 等 |
-| 加工 Y | `./scripts/invoke_as.sh org4 query ListProductsByOwner Org4MSP` | S-X-002, S-X-004 系の残り |
-| 建設 D | `./scripts/invoke_as.sh org5 query ListProductsByOwner Org5MSP` | S-A-001-b / P-B-001 / P-B-020 |
+| 完成済みの加工フロー | Part 1-3 と同形状の DAG を残すため | P-B-001, P-B-002, P-B-020, P-B-040 |
+| **メーカー未出荷在庫** | A / X の portfolio が空にならないよう、複数ロットを製造直後の状態で保持 | S-A-006〜S-A-009, S-X-005〜S-X-009 |
+| **加工業者の仕掛中案件** | 受入済み・分割済みだが接合前 ── 現実の WIP (work in progress) を再現 | S-A-010 + 子 / S-X-010 + 子 |
+| **D への素材直送納品** | 別工区向けの通し納品 (X→Y→D) | S-X-011 |
 
-系譜検証:
+### 投入後の手持ち素材一覧
+
+| 組織 | 確認コマンド | 内容（主なもの） |
+|---|---|---|
+| 高炉 A | `./scripts/invoke_as.sh org1 query ListProductsByOwner Org1MSP` | S-A-002, S-A-006〜S-A-009（未出荷在庫 5 ロット） |
+| 電炉 X | `./scripts/invoke_as.sh org2 query ListProductsByOwner Org2MSP` | S-X-005〜S-X-009（未出荷在庫 5 ロット: H形鋼 / アングル / チャンネル / 鉄筋） |
+| 加工 B | `./scripts/invoke_as.sh org3 query ListProductsByOwner Org3MSP` | S-A-001 系残り, P-B-002, P-B-040, S-A-010 系 (仕掛中) など |
+| 加工 Y | `./scripts/invoke_as.sh org4 query ListProductsByOwner Org4MSP` | S-X-002, S-X-004 系残り, S-X-010 系 (仕掛中) |
+| 建設 D | `./scripts/invoke_as.sh org5 query ListProductsByOwner Org5MSP` | S-A-001-b, P-B-001, P-B-020, S-X-011（素材直送） |
+
+### 取引・処理履歴の可視化
+
+仕掛中案件 `S-A-010` は CREATE → TRANSFER (A→B) → SPLIT の 3 イベントを含む典型パターン:
 ```bash
+./scripts/invoke_as.sh org3 query GetHistory S-A-010
+```
+
+### 系譜検証
+
+```bash
+./scripts/invoke_as.sh org5 query GetLineage P-B-001    # 単純 DAG
 ./scripts/invoke_as.sh org5 query GetLineage P-B-020    # Merge-of-Merge DAG
 ./scripts/invoke_as.sh org3 query GetLineage P-B-040    # Diamond DAG
 ```

--- a/scripts/demo_normal.sh
+++ b/scripts/demo_normal.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# demo_normal.sh — Phase 8: 複合シナリオ (2系統製造 → 分割 → 接合 → 納品)
+# demo_normal.sh — Phase 8: 複合シナリオ (3 部構成)
 #
-# 5Org (A/X/B/Y/D) の鋼材トレーサビリティ。鋼板 S1 を切断して接合素材を作り、
-# 形鋼 S2 と接合して部材 P1 を建設会社 D に納品するフロー。
+# 5Org (A/X/B/Y/D) の鋼材トレーサビリティ。以下の 3 パートで難易度を段階的に上げる。
+#
+#   Part 1: 基本シナリオ (2系統製造 → 分割 → 接合 → 納品)
+#   Part 2: Merge-of-Merge (多段組立: Y 小組 → B 本体組 → 最終組立)
+#   Part 3: Diamond DAG (祖先再マージで経路が 2 本になる)
 #
 # - ナレーション付き (課題提起 → 登場人物紹介)
 # - assert 無し (失敗検知は test_integration.sh)
@@ -59,9 +62,15 @@ pause
 say_narration "■ 登場人物"
 say_note "  高炉メーカー A (Org1MSP) … 鋼板を製造"
 say_note "  電炉メーカー X (Org2MSP) … 形鋼を製造"
-say_note "  加工業者 B     (Org3MSP) … 切断・接合"
-say_note "  加工業者 Y     (Org4MSP) … 切断・接合 (このデモでは登場のみ)"
+say_note "  加工業者 B     (Org3MSP) … 切断・接合 (Part 1/2/3 を担当)"
+say_note "  加工業者 Y     (Org4MSP) … 切断・接合 (Part 2 で小組ユニットを担当)"
 say_note "  建設会社 D     (Org5MSP) … 最終納品先、系譜の検証者"
+pause
+
+say_narration "■ このデモの進め方"
+say_note "  Part 1: 単純な分割+接合で起点メーカーを検証 (約 2 分)"
+say_note "  Part 2: Y が小組を作り B が本体組を作り、最後に両者を接合 (Merge-of-Merge)"
+say_note "  Part 3: 祖先再マージで Diamond DAG ができることを確認"
 pause
 
 if ((FRESH)); then
@@ -83,6 +92,11 @@ say_note "今回の productId:"
 say_note "  鋼板      S1 = ${S1}"
 say_note "  形鋼      S2 = ${S2}"
 say_note "  接合部材  P1 = ${P1}"
+pause
+
+say_narration "============================================================"
+say_narration "  Part 1: 基本シナリオ (2系統製造 → 分割 → 接合 → 納品)"
+say_narration "============================================================"
 pause
 
 # ---------- N1: 高炉メーカー A が鋼板 S1 を製造 ----------
@@ -150,14 +164,175 @@ pause
 # 後続デモ用
 echo "${P1}" > "${REPO_ROOT}/.last_product_id" 2>/dev/null || true
 
+# ============================================================
+#  Part 2: Merge-of-Merge (多段組立)
+# ============================================================
+echo
+say_narration "============================================================"
+say_narration "  Part 2: Merge-of-Merge (多段組立)"
+say_narration "============================================================"
+say_note "実際の建材は「小組 → 本体組 → 最終組立」と段階的に接合される。"
+say_note "親が前段 Merge の結果であるケース (Merge-of-Merge) を実演する。"
+pause
+
+# Part 2 で使う ID
+S3="DEMO-S3-${STAMP}"
+S3A="${S3}-a"
+S3A1="${S3A}-1"
+S3B="${S3}-b"
+PY="DEMO-PY-${STAMP}"
+S4="DEMO-S4-${STAMP}"
+S4X="${S4}-x"
+S4Y="${S4}-y"
+PB="DEMO-PB-${STAMP}"
+PF="DEMO-PF-${STAMP}"
+
+say_note "Part 2 の productId:"
+say_note "  形鋼 (Y 用)    S3 = ${S3}"
+say_note "  鋼板 (B 用)    S4 = ${S4}"
+say_note "  Y 小組         PY = ${PY}"
+say_note "  B 本体組       PB = ${PB}"
+say_note "  最終組立       PF = ${PF}"
+pause
+
+say_section "P2-1: 電炉X が形鋼 ${S3} を製造 → 加工Y へ譲渡"
+S3_META='{"category":"shape","grade":"SM490","weightKg":2000,"heatNo":"HT-X02"}'
+"${INVOKE}" org2 invoke CreateProduct "${S3}" Org2MSP Org2MSP "${S3_META}" "" "demo://millsheet/${S3}.pdf" >/dev/null 2>&1
+"${INVOKE}" org2 invoke TransferProduct "${S3}" Org2MSP Org4MSP >/dev/null 2>&1
+pause
+
+say_section "P2-2: 加工Y が ${S3} を 2 分割 (1 階層目)"
+CHILDREN_P2A='[{"childId":"'${S3A}'","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":1200,\"grade\":\"SM490\"}"},{"childId":"'${S3B}'","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":800,\"grade\":\"SM490\"}"}]'
+"${INVOKE}" org4 invoke SplitProduct "${S3}" "${CHILDREN_P2A}" >/dev/null 2>&1
+pause
+
+say_section "P2-3: 加工Y が ${S3A} をさらに切り出し (2 階層目, DAG 3 階層)"
+CHILDREN_P2B='[{"childId":"'${S3A1}'","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":500,\"grade\":\"SM490\"}"}]'
+"${INVOKE}" org4 invoke SplitProduct "${S3A}" "${CHILDREN_P2B}" >/dev/null 2>&1
+pause
+
+say_section "P2-4: 加工Y が小組 ${PY} を接合 (${S3A1} + ${S3B})"
+PARENTS_PY='["'${S3A1}'","'${S3B}'"]'
+CHILD_PY='{"childId":"'${PY}'","metadataJson":"{\"type\":\"welded\",\"purpose\":\"Y 小組\"}"}'
+"${INVOKE}" org4 invoke MergeProducts "${PARENTS_PY}" "${CHILD_PY}" >/dev/null 2>&1
+pause
+
+say_section "P2-5: 加工Y → 加工B に ${PY} を譲渡 (cross-fabricator)"
+"${INVOKE}" org4 invoke TransferProduct "${PY}" Org4MSP Org3MSP >/dev/null 2>&1
+pause
+
+say_section "P2-6: 高炉A が ${S4} を製造 → 加工B へ譲渡"
+S4_META='{"category":"plate","grade":"SS400","weightKg":8000,"heatNo":"HT-A02"}'
+"${INVOKE}" org1 invoke CreateProduct "${S4}" Org1MSP Org1MSP "${S4_META}" "" "demo://millsheet/${S4}.pdf" >/dev/null 2>&1
+"${INVOKE}" org1 invoke TransferProduct "${S4}" Org1MSP Org3MSP >/dev/null 2>&1
+pause
+
+say_section "P2-7: 加工B が ${S4} を 2 分割"
+CHILDREN_P2C='[{"childId":"'${S4X}'","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":3000,\"grade\":\"SS400\"}"},{"childId":"'${S4Y}'","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":5000,\"grade\":\"SS400\"}"}]'
+"${INVOKE}" org3 invoke SplitProduct "${S4}" "${CHILDREN_P2C}" >/dev/null 2>&1
+pause
+
+say_section "P2-8: 加工B が本体 ${PB} を接合 (${S4X} + ${S4Y})"
+PARENTS_PB='["'${S4X}'","'${S4Y}'"]'
+CHILD_PB='{"childId":"'${PB}'","metadataJson":"{\"type\":\"welded\",\"purpose\":\"B 本体組\"}"}'
+"${INVOKE}" org3 invoke MergeProducts "${PARENTS_PB}" "${CHILD_PB}" >/dev/null 2>&1
+pause
+
+say_section "P2-9: 加工B が最終組立 ${PF} を接合 (${PB} + ${PY}) ← Merge-of-Merge"
+say_note "親 ${PB} (B 本体組) と ${PY} (Y 小組) はどちらも前段 Merge の結果。"
+say_note "→ ${PF} から見ると祖先が 2 系統 (A→B 系, X→Y 系) の DAG になる。"
+PARENTS_PF='["'${PB}'","'${PY}'"]'
+CHILD_PF='{"childId":"'${PF}'","metadataJson":"{\"type\":\"welded\",\"purpose\":\"最終組立ユニット\"}"}'
+"${INVOKE}" org3 invoke MergeProducts "${PARENTS_PF}" "${CHILD_PF}" >/dev/null 2>&1
+pause
+
+say_section "P2-10: 加工B → 建設D に ${PF} を納品"
+"${INVOKE}" org3 invoke TransferProduct "${PF}" Org3MSP Org5MSP >/dev/null 2>&1
+pause
+
+say_section "P2-11: 建設D が ${PF} の系譜を検証 (多段 DAG)"
+LINEAGE_PF="$("${INVOKE}" org5 query GetLineage "${PF}" 2>/dev/null)"
+echo
+say_note "── Nodes ─────────────────────"
+printf '%s' "${LINEAGE_PF}" | jq -r '.nodes[] | "  \(.id)  manufacturer=\(.manufacturer)  owner=\(.currentOwner)  status=\(.status)"'
+echo
+say_note "── Edges (祖先→子孫方向) ─────"
+printf '%s' "${LINEAGE_PF}" | jq -r '.edges[] | "  \(.from) ─\(.type)→ \(.to)"'
+say_note "→ 起点は高炉A (${S4}) と電炉X (${S3}) の 2 系統。中間に PY/PB の Merge 結果が挟まる。"
+pause
+
+# ============================================================
+#  Part 3: Diamond DAG (祖先再マージ)
+# ============================================================
+echo
+say_narration "============================================================"
+say_narration "  Part 3: Diamond DAG (祖先再マージ)"
+say_narration "============================================================"
+say_note "ある素材を切り出して、さらにその子から切り出したものを、元の素材に接合する。"
+say_note "部分加工して戻す工程に相当。最終子から起点まで経路が 2 本できる (Diamond DAG)。"
+pause
+
+# Part 3 で使う ID
+S5="DEMO-S5-${STAMP}"
+S5P="${S5}-p"
+S5P1="${S5P}-1"
+PD="DEMO-PD-${STAMP}"
+
+say_note "Part 3 の productId:"
+say_note "  鋼板           S5    = ${S5}"
+say_note "  切り出し片     S5P   = ${S5P}     (${S5} の子)"
+say_note "  さらに切り出し S5P1  = ${S5P1}    (${S5P} の子)"
+say_note "  Diamond 接合品 PD    = ${PD}      (${S5} + ${S5P1} の Merge)"
+pause
+
+say_section "P3-1: 高炉A が ${S5} を製造 → 加工B へ譲渡"
+S5_META='{"category":"plate","grade":"SS400","weightKg":6000,"heatNo":"HT-A03"}'
+"${INVOKE}" org1 invoke CreateProduct "${S5}" Org1MSP Org1MSP "${S5_META}" "" "demo://millsheet/${S5}.pdf" >/dev/null 2>&1
+"${INVOKE}" org1 invoke TransferProduct "${S5}" Org1MSP Org3MSP >/dev/null 2>&1
+pause
+
+say_section "P3-2: 加工B が ${S5} から ${S5P} を切り出し (${S5} は ACTIVE 継続)"
+CHILDREN_P3A='[{"childId":"'${S5P}'","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":2000,\"grade\":\"SS400\",\"note\":\"ブラケット用\"}"}]'
+"${INVOKE}" org3 invoke SplitProduct "${S5}" "${CHILDREN_P3A}" >/dev/null 2>&1
+pause
+
+say_section "P3-3: 加工B が ${S5P} から ${S5P1} をさらに切り出し (孫階層)"
+CHILDREN_P3B='[{"childId":"'${S5P1}'","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":1000,\"grade\":\"SS400\",\"note\":\"補強材\"}"}]'
+"${INVOKE}" org3 invoke SplitProduct "${S5P}" "${CHILDREN_P3B}" >/dev/null 2>&1
+pause
+
+say_section "P3-4: 加工B が ${S5} + ${S5P1} を接合 → ${PD} (祖先再マージ)"
+say_note "${PD} の直接の親は [${S5}, ${S5P1}]。"
+say_note "加えて ${S5P1} → ${S5P} → ${S5} の経路でも ${S5} に到達する。"
+say_note "→ ${S5} への入エッジが 2 本ある Diamond DAG になる。"
+PARENTS_PD='["'${S5}'","'${S5P1}'"]'
+CHILD_PD='{"childId":"'${PD}'","metadataJson":"{\"type\":\"welded\",\"purpose\":\"祖先再マージ実証\"}"}'
+"${INVOKE}" org3 invoke MergeProducts "${PARENTS_PD}" "${CHILD_PD}" >/dev/null 2>&1
+pause
+
+say_section "P3-5: ${PD} の GetLineage (Diamond DAG 確認)"
+LINEAGE_PD="$("${INVOKE}" org3 query GetLineage "${PD}" 2>/dev/null)"
+echo
+say_note "── Nodes ─────────────────────"
+printf '%s' "${LINEAGE_PD}" | jq -r '.nodes[] | "  \(.id)  manufacturer=\(.manufacturer)  owner=\(.currentOwner)  status=\(.status)"'
+echo
+say_note "── Edges (祖先→子孫方向) ─────"
+printf '%s' "${LINEAGE_PD}" | jq -r '.edges[] | "  \(.from) ─\(.type)→ \(.to)"'
+say_note "→ ${S5} → ${PD} (直接) と ${S5} → ${S5P} → ${S5P1} → ${PD} (間接) の 2 経路が出ている。"
+say_note "  循環は無く DAG として整合。chaincode は祖先再マージを構造的に許容する設計。"
+pause
+
 echo
 say_narration "■ このデモで確認できたこと"
 say_note "  1. 2 系統メーカー (A/X) の鋼材が台帳に並立して登録される"
 say_note "  2. 分割・接合の各操作で親子関係 (parents/children) が自動記録される"
 say_note "  3. 建設会社 D から一覧で起点 (高炉 A / 電炉 X) までたどれる"
-say_note "  4. 親は CONSUMED になり、二重分割や二重接合は chaincode が拒否する"
+say_note "  4. Merge-of-Merge (前段接合の結果をさらに接合) も正しく DAG に表現される"
+say_note "  5. 祖先再マージ (Diamond DAG) でも循環は発生せず、経路が 2 本として現れる"
+say_note "  6. 親の状態遷移 (ACTIVE/CONSUMED) と所有者検査で不正操作は拒否される"
 echo
 say_narration "■ スコープと限界"
 say_note "台帳は「記録の一貫性」を保証する。物理鋼材そのものの真正性 (QR/RFID 等) は別レイヤー。"
 say_note "重量保存則 (分割後 Σ子重量 = 親重量) は PoC スコープ外 - 実装上は検証していない。"
+say_note "GetLineage の深さは LINEAGE_MAX_DEPTH=20 で打ち切る (深い多段加工では要見直し)。"
 echo

--- a/scripts/demo_seed.sh
+++ b/scripts/demo_seed.sh
@@ -5,16 +5,37 @@
 # 複数ロットが各組織に分散して保有されている現実的な在庫状態を作る。
 #
 # 投入結果 (最終状態):
-#   S-A-001   高炉A 鋼板 10t SS400   ACTIVE   (3 片切り出し済、本体は加工B 在庫に残る)
-#   S-A-001-a 切り出し片 3t          CONSUMED (接合素材 → P-B-001)
-#   S-A-001-b 切り出し片 3t          ACTIVE   建設D 直送済
-#   S-A-001-c 切り出し片 4t          CONSUMED (接合素材 → P-B-002)
-#   S-A-002   高炉A 鋼板 8t SS400    ACTIVE   高炉A 在庫 (未出荷)
-#   S-X-001   電炉X 形鋼 2t SM490    CONSUMED (接合素材 → P-B-001)
-#   S-X-002   電炉X 形鋼 3t SM520    ACTIVE   加工Y 在庫 (未加工)
-#   S-X-003   電炉X 形鋼 0.8t SM490  CONSUMED (接合素材 → P-B-002)
-#   P-B-001   接合: S-A-001-a+S-X-001 ACTIVE   建設D 納品済 (柱)
-#   P-B-002   接合: S-A-001-c+S-X-003 ACTIVE   加工B 在庫 (梁)
+#   --- 基本シナリオ (単純な分割 + 接合) -----------------------------
+#   S-A-001    高炉A 鋼板 10t SS400    ACTIVE   (3 片切り出し済、本体は加工B 在庫に残る)
+#   S-A-001-a  切り出し片 3t           CONSUMED (接合素材 → P-B-001)
+#   S-A-001-b  切り出し片 3t           ACTIVE   建設D 直送済
+#   S-A-001-c  切り出し片 4t           CONSUMED (接合素材 → P-B-002)
+#   S-A-002    高炉A 鋼板 8t SS400     ACTIVE   高炉A 在庫 (未出荷)
+#   S-X-001    電炉X 形鋼 2t SM490     CONSUMED (接合素材 → P-B-001)
+#   S-X-002    電炉X 形鋼 3t SM520     ACTIVE   加工Y 在庫 (未加工)
+#   S-X-003    電炉X 形鋼 0.8t SM490   CONSUMED (接合素材 → P-B-002)
+#   P-B-001    接合: S-A-001-a+S-X-001 ACTIVE   建設D 納品済 (柱)
+#   P-B-002    接合: S-A-001-c+S-X-003 ACTIVE   加工B 在庫 (梁)
+#
+#   --- 複雑シナリオ 1-3 (多段切り出し + Merge-of-Merge + Cross-fab) --
+#   加工Y 側で小組 → 加工B 側で本体組 → 両者を最終接合 → 建設D 納品
+#     S-X-004      電炉X 形鋼 2t SM490       ACTIVE   (加工Y が 2 分割した後も残る)
+#     S-X-004-a    切り出し片 1.2t           ACTIVE   (さらに 2 分割した後も残る)
+#     S-X-004-a1   さらに切り出し 0.5t       CONSUMED (P-Y-001 素材)
+#     S-X-004-a2   さらに切り出し 0.7t       ACTIVE   (加工Y 在庫)
+#     S-X-004-b    切り出し片 0.8t           CONSUMED (P-Y-001 素材)
+#     P-Y-001      Y 内製小組 (a1+b)          CONSUMED (P-B-020 素材, B へ譲渡済み)
+#     S-A-003      高炉A 鋼板 8t SS400       ACTIVE   (加工B で 2 分割後も残る)
+#     S-A-003-x    切り出し片 3t             CONSUMED (P-B-010 素材)
+#     S-A-003-y    切り出し片 5t             CONSUMED (P-B-010 素材)
+#     P-B-010      B 内製本体組 (x+y)         CONSUMED (P-B-020 素材)
+#     P-B-020      最終組立 (P-B-010+P-Y-001) ACTIVE   建設D 納品済
+#
+#   --- 複雑シナリオ 4 (Diamond DAG: 祖先再マージ) --------------------
+#     S-A-005      高炉A 鋼板 6t SS400       CONSUMED (P-B-040 素材, 直接親)
+#     S-A-005-p    切り出し片 2t             ACTIVE   (加工B 在庫)
+#     S-A-005-p1   さらに切り出し 1t         CONSUMED (P-B-040 素材, 孫経由で S-A-005 に到達)
+#     P-B-040      祖先再マージ実証 (S-A-005 + S-A-005-p1) ACTIVE   (加工B 在庫)
 #
 # v1.3 以降の「切り出し」モデル: 親は CONSUMED にならず ACTIVE のまま残る。
 # 親の children[] に切り出した子 ID が cumulative に記録される。
@@ -147,11 +168,80 @@ seed_transfer "P-B-001" org3 Org3MSP Org5MSP
 # 7. B が S-A-001-c + S-X-003 を接合 → P-B-002 (梁材, B 社内在庫)
 seed_merge '["S-A-001-c","S-X-003"]' "P-B-002" org3 '{"type":"welded","purpose":"梁","note":"SS400+SM490 小形"}'
 
+# ====================================
+# 複雑シナリオ 1-3: 多段切り出し + Merge-of-Merge + Cross-fabricator
+# ====================================
+#
+# フロー: 加工Y が小組 P-Y-001 を Y 内製 → B に譲渡 (cross-fab)
+#        加工B が S-A-003 を分割→組立で本体 P-B-010 を作成
+#        最後に P-B-010 + P-Y-001 を接合 → P-B-020 (Merge-of-Merge) → 建設D 納品
+
+# 8. 電炉X が S-X-004 を製造 → 加工Y へ譲渡
+seed_create "S-X-004" org2 Org2MSP '{"category":"shape","grade":"SM490","weightKg":2000,"heatNo":"HT-X-004"}'
+seed_transfer "S-X-004" org2 Org2MSP Org4MSP
+
+# 9. 加工Y が S-X-004 を 2 分割 (1 階層目)
+seed_split "S-X-004" org4 '[{"childId":"S-X-004-a","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":1200,\"grade\":\"SM490\",\"note\":\"さらに分割予定\"}"},{"childId":"S-X-004-b","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":800,\"grade\":\"SM490\",\"note\":\"接合用\"}"}]'
+
+# 10. 加工Y が S-X-004-a をさらに 2 分割 (2 階層目 → DAG 3 階層)
+seed_split "S-X-004-a" org4 '[{"childId":"S-X-004-a1","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":500,\"grade\":\"SM490\",\"note\":\"接合用\"}"},{"childId":"S-X-004-a2","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":700,\"grade\":\"SM490\",\"note\":\"予備在庫\"}"}]'
+
+# 11. 加工Y が S-X-004-a1 + S-X-004-b を接合 → P-Y-001 (Y 内製小組)
+seed_merge '["S-X-004-a1","S-X-004-b"]' "P-Y-001" org4 '{"type":"welded","purpose":"小組ブラケット","note":"Y 内製"}'
+
+# 12. Y→B: P-Y-001 を加工Bに送付 (cross-fabricator)
+seed_transfer "P-Y-001" org4 Org4MSP Org3MSP
+
+# 13. 高炉A が S-A-003 を製造 → 加工B へ譲渡
+seed_create "S-A-003" org1 Org1MSP '{"category":"plate","grade":"SS400","weightKg":8000,"heatNo":"HT-A-003"}'
+seed_transfer "S-A-003" org1 Org1MSP Org3MSP
+
+# 14. 加工B が S-A-003 を 2 分割
+seed_split "S-A-003" org3 '[{"childId":"S-A-003-x","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":3000,\"grade\":\"SS400\",\"note\":\"本体ウェブ\"}"},{"childId":"S-A-003-y","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":5000,\"grade\":\"SS400\",\"note\":\"本体フランジ\"}"}]'
+
+# 15. 加工B が x+y を接合 → P-B-010 (B 内製本体組)
+seed_merge '["S-A-003-x","S-A-003-y"]' "P-B-010" org3 '{"type":"welded","purpose":"本体ウェブ+フランジ","note":"B 内製"}'
+
+# 16. 加工B が P-B-010 + P-Y-001 を接合 → P-B-020 (Merge-of-Merge)
+#     親の両方が「前段 Merge の結果」であり、DAG が 3 階層以上になる典型パターン。
+seed_merge '["P-B-010","P-Y-001"]' "P-B-020" org3 '{"type":"welded","purpose":"最終組立ユニット","note":"本体+小組ブラケット"}'
+
+# 17. B→D: P-B-020 を建設Dに納品
+seed_transfer "P-B-020" org3 Org3MSP Org5MSP
+
+# ====================================
+# 複雑シナリオ 4: Diamond DAG (祖先再マージ)
+# ====================================
+#
+# ある素材を一部切り出し、その子からさらに切り出したものを、元の素材に戻して接合する。
+# 結果的に最終子 P-B-040 から起点 S-A-005 までの経路が 2 本できる (直接 / 孫経由)。
+
+# 18. 高炉A が S-A-005 を製造 → 加工B へ譲渡
+seed_create "S-A-005" org1 Org1MSP '{"category":"plate","grade":"SS400","weightKg":6000,"heatNo":"HT-A-005"}'
+seed_transfer "S-A-005" org1 Org1MSP Org3MSP
+
+# 19. 加工B が S-A-005 から S-A-005-p を切り出し (S-A-005 は ACTIVE のまま)
+seed_split "S-A-005" org3 '[{"childId":"S-A-005-p","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":2000,\"grade\":\"SS400\",\"note\":\"ブラケット用途\"}"}]'
+
+# 20. 加工B が S-A-005-p から S-A-005-p1 を切り出し (孫階層)
+seed_split "S-A-005-p" org3 '[{"childId":"S-A-005-p1","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":1000,\"grade\":\"SS400\",\"note\":\"補強材\"}"}]'
+
+# 21. 加工B が S-A-005 + S-A-005-p1 を接合 → P-B-040 (祖先再マージ)
+#     P-B-040 の parents は [S-A-005, S-A-005-p1]。
+#     さらに S-A-005-p1 → S-A-005-p → S-A-005 の経路でも祖先 S-A-005 に到達できる。
+seed_merge '["S-A-005","S-A-005-p1"]' "P-B-040" org3 '{"type":"welded","purpose":"祖先再マージ実証","note":"S-A-005 由来を 2 経路で保持"}'
+
 echo
 ok "サンプルデータ投入完了"
 echo
-echo "${C_DIM}確認コマンド:${C_OFF}"
-echo "  ./scripts/invoke_as.sh org3 query ListProductsByOwner Org3MSP   # 加工B 手持ち (S-A-001 系と P-B-002)"
-echo "  ./scripts/invoke_as.sh org4 query ListProductsByOwner Org4MSP   # 加工Y 手持ち (S-X-002)"
-echo "  ./scripts/invoke_as.sh org5 query ListProductsByOwner Org5MSP   # 建設D 手持ち (S-A-001-b と P-B-001)"
-echo "  ./scripts/invoke_as.sh org5 query GetLineage P-B-001            # P-B-001 系譜 (A と X 起点が見える)"
+echo "${C_DIM}確認コマンド (基本シナリオ):${C_OFF}"
+echo "  ./scripts/invoke_as.sh org3 query ListProductsByOwner Org3MSP   # 加工B 手持ち"
+echo "  ./scripts/invoke_as.sh org4 query ListProductsByOwner Org4MSP   # 加工Y 手持ち"
+echo "  ./scripts/invoke_as.sh org5 query ListProductsByOwner Org5MSP   # 建設D 手持ち"
+echo "  ./scripts/invoke_as.sh org5 query GetLineage P-B-001            # 単純 DAG (A と X の 2 系統)"
+echo
+echo "${C_DIM}確認コマンド (複雑シナリオ):${C_OFF}"
+echo "  ./scripts/invoke_as.sh org5 query GetLineage P-B-020            # Merge-of-Merge: 4 階層 DAG"
+echo "  ./scripts/invoke_as.sh org3 query GetLineage P-B-040            # Diamond DAG: S-A-005 へ 2 経路"
+echo "  ./scripts/invoke_as.sh org3 query GetHistory  S-A-005           # 祖先再マージで CONSUMED に至る履歴"
+echo "  ./scripts/invoke_as.sh org4 query GetHistory  S-X-004           # 多段切り出しで children[] が育つ履歴"

--- a/scripts/demo_seed.sh
+++ b/scripts/demo_seed.sh
@@ -37,6 +37,33 @@
 #     S-A-005-p1   さらに切り出し 1t         CONSUMED (P-B-040 素材, 孫経由で S-A-005 に到達)
 #     P-B-040      祖先再マージ実証 (S-A-005 + S-A-005-p1) ACTIVE   (加工B 在庫)
 #
+#   --- 業務リアリティ向上: メーカー在庫 + 仕掛中案件 ----------------
+#   高炉A 未出荷在庫 (手持ち 5 ロット: S-A-002 含む):
+#     S-A-006  SM490 15t   大型梁材向け     ACTIVE   高炉A 保有
+#     S-A-007  SM520 12t   橋梁用高強度     ACTIVE   高炉A 保有
+#     S-A-008  SS400 10t   柱材向け標準品   ACTIVE   高炉A 保有
+#     S-A-009  SS400 5t    補修用小ロット   ACTIVE   高炉A 保有
+#
+#   電炉X 未出荷在庫 (手持ち 5 ロット):
+#     S-X-005  H形鋼 SM490 5t  汎用梁材     ACTIVE   電炉X 保有
+#     S-X-006  H形鋼 SM520 8t  大型梁材     ACTIVE   電炉X 保有
+#     S-X-007  アングル SS400 2t           ACTIVE   電炉X 保有
+#     S-X-008  チャンネル SM490 3t          ACTIVE   電炉X 保有
+#     S-X-009  鉄筋 SD345 4t                ACTIVE   電炉X 保有
+#
+#   加工B 仕掛中 (受入→分割、接合待ち):
+#     S-A-010    A→B 譲渡済 6t SS400       ACTIVE   (親、2 分割済みで ACTIVE 継続)
+#     S-A-010-a  切り出し 3t 接合待ち       ACTIVE   加工B 保有
+#     S-A-010-b  切り出し 3t 接合待ち       ACTIVE   加工B 保有
+#
+#   加工Y 仕掛中 (受入→分割、接合待ち):
+#     S-X-010    X→Y 譲渡済 4t アングル    ACTIVE   (親、2 分割済み)
+#     S-X-010-a  切り出し 2t 接合待ち       ACTIVE   加工Y 保有
+#     S-X-010-b  切り出し 2t 接合待ち       ACTIVE   加工Y 保有
+#
+#   建設D 別工区納品 (素材直送):
+#     S-X-011    鉄筋 SD390 3t              ACTIVE   (X→Y→D の通し納品)
+#
 # v1.3 以降の「切り出し」モデル: 親は CONSUMED にならず ACTIVE のまま残る。
 # 親の children[] に切り出した子 ID が cumulative に記録される。
 #
@@ -231,17 +258,78 @@ seed_split "S-A-005-p" org3 '[{"childId":"S-A-005-p1","toOwner":"Org3MSP","metad
 #     さらに S-A-005-p1 → S-A-005-p → S-A-005 の経路でも祖先 S-A-005 に到達できる。
 seed_merge '["S-A-005","S-A-005-p1"]' "P-B-040" org3 '{"type":"welded","purpose":"祖先再マージ実証","note":"S-A-005 由来を 2 経路で保持"}'
 
+# ====================================
+# 業務リアリティ向上: メーカー在庫 + 加工業者の仕掛中案件
+# ====================================
+#
+# 各社の手持ち素材を現実に近づけるための追加投入。
+# - 高炉A / 電炉X: 未出荷の在庫ロット (受注前 / 受注分 / 補修用の区別)
+# - 加工B / 加工Y: 仕掛中の加工ジョブ (受入→分割後でまだ接合/納品前)
+
+# --- 高炉A 未出荷在庫 (4 ロット) ------------------------------------
+# 22. S-A-006: 大型梁材向け SM490 (受注残り待ち)
+seed_create "S-A-006" org1 Org1MSP '{"category":"plate","grade":"SM490","weightKg":15000,"heatNo":"HT-A-006","note":"大型梁材向け"}'
+
+# 23. S-A-007: 橋梁用高強度 SM520 (プレミアム在庫)
+seed_create "S-A-007" org1 Org1MSP '{"category":"plate","grade":"SM520","weightKg":12000,"heatNo":"HT-A-007","note":"橋梁用高強度"}'
+
+# 24. S-A-008: 汎用 SS400 10t (柱材向け標準品)
+seed_create "S-A-008" org1 Org1MSP '{"category":"plate","grade":"SS400","weightKg":10000,"heatNo":"HT-A-008","note":"柱材向け標準品"}'
+
+# 25. S-A-009: 小ロット補修用 SS400 5t
+seed_create "S-A-009" org1 Org1MSP '{"category":"plate","grade":"SS400","weightKg":5000,"heatNo":"HT-A-009","note":"補修用小ロット"}'
+
+# --- 電炉X 未出荷在庫 (5 ロット) ------------------------------------
+# 26. S-X-005: H 形鋼 SM490 5t (汎用)
+seed_create "S-X-005" org2 Org2MSP '{"category":"h-beam","grade":"SM490","weightKg":5000,"heatNo":"HT-X-005","note":"H形鋼 汎用梁材"}'
+
+# 27. S-X-006: H 形鋼 SM520 8t (大型)
+seed_create "S-X-006" org2 Org2MSP '{"category":"h-beam","grade":"SM520","weightKg":8000,"heatNo":"HT-X-006","note":"大型梁材"}'
+
+# 28. S-X-007: 等辺アングル SS400 2t
+seed_create "S-X-007" org2 Org2MSP '{"category":"angle","grade":"SS400","weightKg":2000,"heatNo":"HT-X-007","note":"ブレース用アングル"}'
+
+# 29. S-X-008: チャンネル SM490 3t
+seed_create "S-X-008" org2 Org2MSP '{"category":"channel","grade":"SM490","weightKg":3000,"heatNo":"HT-X-008","note":"チャンネル材"}'
+
+# 30. S-X-009: 異形棒鋼 SD345 4t (鉄筋)
+seed_create "S-X-009" org2 Org2MSP '{"category":"rebar","grade":"SD345","weightKg":4000,"heatNo":"HT-X-009","note":"鉄筋 D25"}'
+
+# --- 加工B 仕掛中 (受入→分割中、接合前) ----------------------------
+# 31. 高炉A が S-A-010 を製造 → 加工B へ譲渡
+seed_create "S-A-010" org1 Org1MSP '{"category":"plate","grade":"SS400","weightKg":6000,"heatNo":"HT-A-010","note":"B受注分"}'
+seed_transfer "S-A-010" org1 Org1MSP Org3MSP
+
+# 32. 加工B が S-A-010 を 2 分割 (接合はまだ未着手 = 仕掛中)
+seed_split "S-A-010" org3 '[{"childId":"S-A-010-a","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":3000,\"grade\":\"SS400\",\"note\":\"接合待ち\"}"},{"childId":"S-A-010-b","toOwner":"Org3MSP","metadataJson":"{\"weightKg\":3000,\"grade\":\"SS400\",\"note\":\"接合待ち\"}"}]'
+
+# --- 加工Y 仕掛中 (受入→分割中、接合前) ----------------------------
+# 33. 電炉X が S-X-010 を製造 → 加工Y へ譲渡
+seed_create "S-X-010" org2 Org2MSP '{"category":"angle","grade":"SS400","weightKg":4000,"heatNo":"HT-X-010","note":"Y受注分"}'
+seed_transfer "S-X-010" org2 Org2MSP Org4MSP
+
+# 34. 加工Y が S-X-010 を 2 分割 (接合待ち)
+seed_split "S-X-010" org4 '[{"childId":"S-X-010-a","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":2000,\"grade\":\"SS400\",\"note\":\"接合待ち\"}"},{"childId":"S-X-010-b","toOwner":"Org4MSP","metadataJson":"{\"weightKg\":2000,\"grade\":\"SS400\",\"note\":\"接合待ち\"}"}]'
+
+# --- 建設D 追加納品 (過去の別工区) ----------------------------------
+# 35. 電炉X が S-X-011 (鉄筋ロット) を製造 → 加工Y → 建設D へ通し納品
+#     D の手持ちに「素材をそのまま納品された鉄筋」パターンも追加。
+seed_create "S-X-011" org2 Org2MSP '{"category":"rebar","grade":"SD390","weightKg":3000,"heatNo":"HT-X-011","note":"D 別工区向け鉄筋"}'
+seed_transfer "S-X-011" org2 Org2MSP Org4MSP
+seed_transfer "S-X-011" org4 Org4MSP Org5MSP
+
 echo
 ok "サンプルデータ投入完了"
 echo
-echo "${C_DIM}確認コマンド (基本シナリオ):${C_OFF}"
-echo "  ./scripts/invoke_as.sh org3 query ListProductsByOwner Org3MSP   # 加工B 手持ち"
+echo "${C_DIM}確認コマンド (各社の手持ち):${C_OFF}"
+echo "  ./scripts/invoke_as.sh org1 query ListProductsByOwner Org1MSP   # 高炉A 未出荷在庫 (S-A-002, 006-009)"
+echo "  ./scripts/invoke_as.sh org2 query ListProductsByOwner Org2MSP   # 電炉X 未出荷在庫 (S-X-005-009)"
+echo "  ./scripts/invoke_as.sh org3 query ListProductsByOwner Org3MSP   # 加工B 手持ち (仕掛中 + 完成品)"
 echo "  ./scripts/invoke_as.sh org4 query ListProductsByOwner Org4MSP   # 加工Y 手持ち"
-echo "  ./scripts/invoke_as.sh org5 query ListProductsByOwner Org5MSP   # 建設D 手持ち"
-echo "  ./scripts/invoke_as.sh org5 query GetLineage P-B-001            # 単純 DAG (A と X の 2 系統)"
+echo "  ./scripts/invoke_as.sh org5 query ListProductsByOwner Org5MSP   # 建設D 納品済み"
 echo
 echo "${C_DIM}確認コマンド (複雑シナリオ):${C_OFF}"
+echo "  ./scripts/invoke_as.sh org5 query GetLineage P-B-001            # 単純 DAG (A と X の 2 系統)"
 echo "  ./scripts/invoke_as.sh org5 query GetLineage P-B-020            # Merge-of-Merge: 4 階層 DAG"
 echo "  ./scripts/invoke_as.sh org3 query GetLineage P-B-040            # Diamond DAG: S-A-005 へ 2 経路"
-echo "  ./scripts/invoke_as.sh org3 query GetHistory  S-A-005           # 祖先再マージで CONSUMED に至る履歴"
-echo "  ./scripts/invoke_as.sh org4 query GetHistory  S-X-004           # 多段切り出しで children[] が育つ履歴"
+echo "  ./scripts/invoke_as.sh org3 query GetHistory  S-A-010           # 仕掛中案件の履歴 (CREATE/TRANSFER/SPLIT)"


### PR DESCRIPTION
## Summary

- **demo_normal.sh**: 3 部構成に再編 (Part 1 基本 / Part 2 Merge-of-Merge / Part 3 Diamond DAG)。CLI デモで多段組立と祖先再マージの DAG 挙動を実演可能に。
- **demo_seed.sh**: Merge-of-Merge / Diamond DAG のサンプル素材に加え、各社の業務リアル portfolio (A/X の未出荷在庫 + B/Y の仕掛中案件 + D の別工区納品) を投入。
- **docs/demo-scenarios.md**: v1 (3Org 譲渡のみ) を v2 (5Org + Split/Merge + 3 部構成) に全面刷新。拡張エラーコード (`PARENT_NOT_ACTIVE` / `PARENTS_OWNER_DIVERGENT` / `LINEAGE_DEPTH_EXCEEDED`) も追加。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `scripts/demo_normal.sh` | 3 部構成に再編、Part 2/3 の新シナリオ追加 |
| `scripts/demo_seed.sh` | 複雑シナリオ + メーカー在庫 / 仕掛中 / 直送納品 |
| `docs/demo-scenarios.md` | v2 向け全面刷新 |
| `README.md` | Quick Start で 3 部構成とデモ台本リンクを明示 |

## 背景・設計メモ

- v1.3 以降の「切り出し」モデル (親 ACTIVE 維持 / N>=1) を前提に、多段分岐の DAG パターンを網羅
- **Diamond DAG**: 祖先を再マージするケースでも循環せず、経路が 2 本として現れることを実演 (chaincode 側の検証として有用)
- 投入素材の `heatNo` / `category` / `note` を業務用語で差別化し、UI 上で各社の在庫状況が一目で区別できる

## 関連 Issue

- 関連議論: #12 (Lineage DAG 拡張: 全アクション可視化 + 下流方向は距離1に制限) — 本 PR ではデモ素材の拡充が目的で、Lineage API 自体の変更は別 PR で対応予定

## Test plan

- [x] `bash -n scripts/demo_seed.sh` / `bash -n scripts/demo_normal.sh` 構文チェック通過
- [x] 埋め込み JSON リテラルを Python `json.loads` で検証、全 parse 成功
- [x] chaincode 側は一切変更していないため L1 単体テスト (`cd chaincode/product-trace && npm test`) 影響なし
- [ ] 実機確認 (レビュー時):
  - [ ] `./scripts/demo_normal.sh --fresh` が Part 1〜3 を完走
  - [ ] `./scripts/demo_seed.sh` 実行後、`ListProductsByOwner Org1MSP` / `Org2MSP` が複数件返却
  - [ ] `GetLineage P-B-020` が Merge-of-Merge 4 階層 DAG を返却
  - [ ] `GetLineage P-B-040` が S-A-005 へ 2 経路の Diamond DAG を返却
  - [ ] Web UI でメーカー A / X の手持ち素材が空でないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)