### PR TITLE
feat(scripts): web_demo.sh --fresh / --seed で Web デモを一発起動

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Endorsement policy: `OR('Org1MSP.peer',...,'Org5MSP.peer')`
 - 分割・接合フォーム / Mermaid による系譜 DAG 可視化
 - サンプル素材の冪等投入: `./scripts/demo_seed.sh` (単純 DAG + Merge-of-Merge + Diamond DAG を含む)
 
+**Web デモを一発で立ち上げる**:
+```bash
+./scripts/web_demo.sh --fresh   # reset → network_up → deploy → seed → web
+./scripts/web_demo.sh --seed    # 既存 NW にサンプルだけ追加投入 → web
+```
+
 クリーンアップ: `./scripts/reset.sh --yes`
 
 ## 前提環境

--- a/scripts/web_demo.sh
+++ b/scripts/web_demo.sh
@@ -2,10 +2,13 @@
 # web_demo.sh — Web デモ UI 起動スクリプト
 #
 # Usage:
-#   ./scripts/web_demo.sh          # Web サーバー起動
-#   ./scripts/web_demo.sh --stop   # 停止（バックグラウンド実行時）
+#   ./scripts/web_demo.sh            # Web サーバー起動 (NW + deploy 済み前提)
+#   ./scripts/web_demo.sh --fresh    # reset → network_up → deploy → seed → web
+#                                    # クリーン状態から一発で完成形のデモが立ち上がる
+#   ./scripts/web_demo.sh --seed     # 既存 NW にサンプル素材だけ追加投入 → web
+#   ./scripts/web_demo.sh --stop     # バックグラウンド起動時の停止
 #
-# 前提:
+# 前提 (--fresh 以外):
 #   - Fabric ネットワーク起動済み (./scripts/network_up.sh)
 #   - Chaincode デプロイ済み (./scripts/deploy_chaincode.sh)
 
@@ -27,21 +30,43 @@ log()  { echo "${C_HDR}[web-demo]${C_OFF} $*"; }
 ok()   { echo "${C_OK}[web-demo]${C_OFF} $*"; }
 err()  { echo "${C_ERR}[web-demo]${C_OFF} $*" >&2; }
 
-# --stop: kill running server
-if [[ "${1:-}" == "--stop" ]]; then
-  if [[ -f "${WEB_DIR}/.pid" ]]; then
-    PID=$(cat "${WEB_DIR}/.pid")
-    if kill -0 "$PID" 2>/dev/null; then
-      kill "$PID"
-      ok "Server stopped (PID=$PID)"
-    else
-      log "Server not running (stale PID=$PID)"
-    fi
-    rm -f "${WEB_DIR}/.pid"
-  else
-    log "No .pid file found"
-  fi
-  exit 0
+FRESH=0
+SEED=0
+for arg in "$@"; do
+  case "${arg}" in
+    --fresh) FRESH=1 ;;
+    --seed)  SEED=1  ;;
+    --stop)
+      if [[ -f "${WEB_DIR}/.pid" ]]; then
+        PID=$(cat "${WEB_DIR}/.pid")
+        if kill -0 "$PID" 2>/dev/null; then
+          kill "$PID"
+          ok "Server stopped (PID=$PID)"
+        else
+          log "Server not running (stale PID=$PID)"
+        fi
+        rm -f "${WEB_DIR}/.pid"
+      else
+        log "No .pid file found"
+      fi
+      exit 0
+      ;;
+    -h|--help)
+      sed -n '2,13p' "$0"
+      exit 0
+      ;;
+    *) err "unknown option: ${arg}"; exit 2 ;;
+  esac
+done
+
+# --- --fresh: NW 再構築から一気通貫 ---
+if (( FRESH )); then
+  log "==== --fresh: reset → network_up → deploy → seed → web ===="
+  "${SCRIPT_DIR}/reset.sh" --yes
+  "${SCRIPT_DIR}/network_up.sh"
+  "${SCRIPT_DIR}/deploy_chaincode.sh"
+  "${SCRIPT_DIR}/demo_seed.sh"
+  ok "--fresh: クリーン状態から台帳準備まで完了"
 fi
 
 # --- Preflight checks ---
@@ -74,6 +99,13 @@ if ! "${PEER_BIN}" lifecycle chaincode querycommitted -C "${CHANNEL_NAME}" -n "$
   exit 1
 fi
 ok "Chaincode '${CC_NAME}' デプロイ済み"
+
+# --- --seed: 既存 NW にサンプル素材を冪等投入 ---
+# --fresh の場合は上で投入済みなのでスキップ
+if (( SEED && !FRESH )); then
+  log "==== --seed: demo_seed.sh 実行 ===="
+  "${SCRIPT_DIR}/demo_seed.sh"
+fi
 
 # --- npm install ---
 


### PR DESCRIPTION
## Summary

- `web_demo.sh` に `--fresh` オプションを追加し、`reset → network_up → deploy_chaincode → demo_seed → web` を一気通貫で実行できるようにした
- `--seed` オプションで既存 NW に対する冪等サンプル投入 + web 起動も可能
- 既存挙動 (オプション無し / `--stop`) は非互換変更なし

## 使い方

```bash
# クリーン状態から Web デモを一発起動 (サンプル素材投入済み)
./scripts/web_demo.sh --fresh

# 既存 NW にサンプル素材だけ追加投入してから Web 起動
./scripts/web_demo.sh --seed

# 既存の使い方 (NW + deploy 済み前提)
./scripts/web_demo.sh

# 停止
./scripts/web_demo.sh --stop
```

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `scripts/web_demo.sh` | 引数パースを `for arg in "$@"` に統一し `--fresh` / `--seed` / `--help` を追加。`--fresh` 時は 4 つの前段スクリプトを順に exec |
| `README.md` | Quick Start の「ブラウザ版デモ」節に一発起動コマンドを明記 |

## 設計メモ

- `--fresh` は既存の `demo_normal.sh --fresh` と同じ設計思想を踏襲 (CLAUDE.md スクリプト規約: `--fresh で reset→up→deploy 連動可`)
- `--fresh` 時は最後に `demo_seed.sh` も走らせることで、空台帳ではなく業務リアルな portfolio (A/X の在庫 + B/Y の仕掛中) が入った状態で UI が立ち上がる
- `--seed` と `--fresh` を同時に指定されても二重投入しないようガード (`SEED && !FRESH`)

## Test plan

- [x] `bash -n scripts/web_demo.sh` 構文チェック通過
- [x] `./scripts/web_demo.sh --help` で Usage コメントが表示されることを確認
- [x] `./scripts/web_demo.sh --unknown` で unknown option エラー (exit 2)
- [ ] 実機確認 (レビュー時):
  - [ ] `./scripts/web_demo.sh --fresh` でクリーン状態から Web サーバー起動まで完走
  - [ ] 起動後ブラウザで A/X の portfolio が空でないこと
  - [ ] `./scripts/web_demo.sh --seed` で既存 NW にサンプルが冪等追加されること
  - [ ] `./scripts/web_demo.sh` (引数無し) が従来どおり動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)